### PR TITLE
Style/#26 popup UI 구현

### DIFF
--- a/Spoony-iOS/Spoony-iOS.xcodeproj/project.pbxproj
+++ b/Spoony-iOS/Spoony-iOS.xcodeproj/project.pbxproj
@@ -335,7 +335,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Spoony-iOS/Preview Content\"";
@@ -359,7 +359,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.Spoony-iOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = SpoonyDebug;
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = SpoonyRelease;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyButton.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyButton.swift
@@ -70,20 +70,20 @@ public struct SpoonyButton: View {
                     .font(size.font)
                     .foregroundStyle(style.foregroundColor)
             }
+            .frame(width: size.width, height: size.height)
+            .background(backgroundColor)
+            .cornerRadius(size.cornerRadius)
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        isSelected = true
+                    }
+                    .onEnded { _ in
+                        isSelected = false
+                        action()
+                    }
+            )
         }
-        .frame(width: size.width, height: size.height)
-        .background(backgroundColor)
-        .cornerRadius(size.cornerRadius)
-        .gesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { _ in
-                    isSelected = true
-                }
-                .onEnded { _ in
-                    isSelected = false
-                    action()
-                }
-        )
         .disabled(disabled)
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
@@ -12,7 +12,7 @@ extension View {
         self.modifier(ToastModifier(toast: toast))
     }
     
-    func popup(popup: PopupType, isPresented: Binding<Bool>) -> some View {
-        modifier(PopupModifier(popup: popup, isPresented: isPresented))
+    func popup(popup: PopupType, isPresented: Binding<Bool>, action: @escaping () -> Void) -> some View {
+        modifier(PopupModifier(popup: popup, isPresented: isPresented, confirmAction: action))
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
@@ -11,4 +11,8 @@ extension View {
     func toastView(toast: Binding<Toast?>) -> some View {
         self.modifier(ToastModifier(toast: toast))
     }
+    
+    func popup(popup: PopupType, isPresented: Binding<Bool>) -> some View {
+        modifier(PopupModifier(popup: popup, isPresented: isPresented))
+    }
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
@@ -58,9 +58,7 @@ struct PopupView: View {
                         title: title,
                         disabled: .constant(false)
                     ) {
-                        print("gray button tapped")
                         isPresented = false
-                        print("ispresented: \(isPresented)")
                     }
                     
                     SpoonyButton(
@@ -77,8 +75,7 @@ struct PopupView: View {
                         style: .secondary,
                         size: .large,
                         title: blackButtonTitle,
-                        isIcon: true,
-                        disabled: .constant(true)
+                        disabled: .constant(false)
                     ) {
                         confirmAction()
                         isPresented = false
@@ -154,15 +151,7 @@ extension PopupView {
             12
         }
     }
-    
-    private var isTwoButton: Bool {
-        switch popup {
-        case .useSpoon:
-            true
-        case .registerSuccess, .reportSuccess:
-            false
-        }
-    }
+
 }
 
 #Preview {

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
@@ -44,7 +44,7 @@ struct PopupView: View {
                 .frame(height: 20)
             if let image {
                 Image(image)
-//                    .resizable()
+                    .resizable()
                     .scaledToFit()
                     .frame(width: 150, height: 150)
             }

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
@@ -33,7 +33,6 @@ enum PopupType {
 struct PopupView: View {
     let popup: PopupType
     @Binding var isPresented: Bool
-    @State private var disabled: Bool = false
     
     var body: some View {
         VStack(spacing: 20) {
@@ -57,7 +56,7 @@ struct PopupView: View {
                         style: .teritary,
                         size: .xsmall,
                         title: title,
-                        disabled: $disabled
+                        disabled: .constant(false)
                     ) {
                         print("gray button tapped")
                         isPresented = false
@@ -68,7 +67,7 @@ struct PopupView: View {
                         style: .secondary,
                         size: .xsmall,
                         title: blackButtonTitle,
-                        disabled: $disabled
+                        disabled: .constant(false)
                     ) {
                         confirmAction()
                         isPresented = false
@@ -78,11 +77,11 @@ struct PopupView: View {
                         style: .secondary,
                         size: .large,
                         title: blackButtonTitle,
-                        disabled: $disabled
+                        isIcon: true,
+                        disabled: .constant(true)
                     ) {
                         confirmAction()
                         isPresented = false
-                        print("ispresented: \(isPresented)")
                     }
                 }
             }

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
@@ -1,0 +1,171 @@
+//
+//  PopupModifier.swift
+//  Spoony-iOS
+//
+//  Created by 최주리 on 1/12/25.
+//
+
+import SwiftUI
+
+struct PopupModifier: ViewModifier {
+    let popup: PopupType
+    @Binding var isPresented: Bool
+    
+    func body(content: Content) -> some View {
+        ZStack {
+            content
+            if isPresented {
+                Color.black.opacity(0.6)
+                    .ignoresSafeArea()
+                    
+                PopupView(popup: popup, isPresented: $isPresented)
+            }
+        }
+    }
+}
+
+enum PopupType {
+    case useSpoon(action: () -> Void)
+    case reportSuccess(action: () -> Void)
+    case registerSuccess(action: () -> Void)
+}
+
+struct PopupView: View {
+    let popup: PopupType
+    @Binding var isPresented: Bool
+    @State private var disabled: Bool = false
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            Spacer()
+                .frame(height: 20)
+            if let image {
+                Image(image)
+                    .resizable()
+                    .scaledToFit()
+                    .frame(width: 150, height: 150)
+            }
+            
+            Text(description)
+                .multilineTextAlignment(.center)
+                .font(.body1b)
+                .padding(.bottom, descriptionYOffset)
+            
+            HStack(spacing: 12) {
+                if let title = grayButtonTitle {
+                    SpoonyButton(
+                        style: .teritary,
+                        size: .xsmall,
+                        title: title,
+                        disabled: $disabled
+                    ) {
+                        print("gray button tapped")
+                        isPresented = false
+                        print("ispresented: \(isPresented)")
+                    }
+                    
+                    SpoonyButton(
+                        style: .secondary,
+                        size: .xsmall,
+                        title: blackButtonTitle,
+                        disabled: $disabled
+                    ) {
+                        confirmAction()
+                        isPresented = false
+                    }
+                } else {
+                    SpoonyButton(
+                        style: .secondary,
+                        size: .large,
+                        title: blackButtonTitle,
+                        disabled: $disabled
+                    ) {
+                        confirmAction()
+                        isPresented = false
+                        print("ispresented: \(isPresented)")
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .background(.white, in: RoundedRectangle(cornerRadius: 16))
+    }
+}
+
+extension PopupView {
+    // 임시
+    private var image: ImageResource? {
+        switch popup {
+        case .useSpoon:
+            return .icBarBlue
+        case .registerSuccess:
+            return .icAmericanBlue
+        case .reportSuccess:
+            return nil
+        }
+    }
+    
+    private var description: String {
+        switch popup {
+        case .useSpoon:
+            "수저 1개를 사용하여 떠먹어 볼까요?"
+        case .registerSuccess:
+            "수저 1개를 획득했어요!\n이제 새로운 장소를 떠먹으러 가볼까요?"
+        case .reportSuccess:
+            "신고가 접수되었어요"
+        }
+    }
+    
+    private var blackButtonTitle: String {
+        switch popup {
+        case .useSpoon:
+            "떠먹을래요"
+        case .registerSuccess:
+            "갈래요!"
+        case .reportSuccess:
+            "확인"
+        }
+    }
+    
+    private var grayButtonTitle: String? {
+        switch popup {
+        case .useSpoon:
+            "아니요"
+        case .registerSuccess, .reportSuccess:
+            nil
+        }
+    }
+    
+    private var confirmAction: () -> Void {
+        switch popup {
+        case .useSpoon(let action):
+            action
+        case .registerSuccess(let action):
+            action
+        case .reportSuccess(let action):
+            action
+        }
+    }
+    
+    private var descriptionYOffset: CGFloat {
+        switch popup {
+        case .useSpoon, .registerSuccess:
+            0
+        case .reportSuccess:
+            12
+        }
+    }
+    
+    private var isTwoButton: Bool {
+        switch popup {
+        case .useSpoon:
+            true
+        case .registerSuccess, .reportSuccess:
+            false
+        }
+    }
+}
+
+#Preview {
+    PopupView(popup: .useSpoon(action: {}), isPresented: .constant(true))
+}

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct PopupModifier: ViewModifier {
     let popup: PopupType
     @Binding var isPresented: Bool
+    let confirmAction: () -> Void
     
     func body(content: Content) -> some View {
         ZStack {
@@ -17,22 +18,25 @@ struct PopupModifier: ViewModifier {
             if isPresented {
                 Color.black.opacity(0.6)
                     .ignoresSafeArea()
-                    
-                PopupView(popup: popup, isPresented: $isPresented)
+                
+                PopupView(popup: popup, isPresented: $isPresented) {
+                    confirmAction()
+                }
             }
         }
     }
 }
 
 enum PopupType {
-    case useSpoon(action: () -> Void)
-    case reportSuccess(action: () -> Void)
-    case registerSuccess(action: () -> Void)
+    case useSpoon
+    case reportSuccess
+    case registerSuccess
 }
 
 struct PopupView: View {
     let popup: PopupType
     @Binding var isPresented: Bool
+    let confirmAction: () -> Void
     
     var body: some View {
         VStack(spacing: 20) {
@@ -40,7 +44,7 @@ struct PopupView: View {
                 .frame(height: 20)
             if let image {
                 Image(image)
-                    .resizable()
+//                    .resizable()
                     .scaledToFit()
                     .frame(width: 150, height: 150)
             }
@@ -60,26 +64,15 @@ struct PopupView: View {
                     ) {
                         isPresented = false
                     }
-                    
-                    SpoonyButton(
-                        style: .secondary,
-                        size: .xsmall,
-                        title: blackButtonTitle,
-                        disabled: .constant(false)
-                    ) {
-                        confirmAction()
-                        isPresented = false
-                    }
-                } else {
-                    SpoonyButton(
-                        style: .secondary,
-                        size: .large,
-                        title: blackButtonTitle,
-                        disabled: .constant(false)
-                    ) {
-                        confirmAction()
-                        isPresented = false
-                    }
+                }
+                SpoonyButton(
+                    style: .secondary,
+                    size: grayButtonTitle == nil ? .large : .xsmall,
+                    title: blackButtonTitle,
+                    disabled: .constant(false)
+                ) {
+                    confirmAction()
+                    isPresented = false
                 }
             }
         }
@@ -132,17 +125,6 @@ extension PopupView {
         }
     }
     
-    private var confirmAction: () -> Void {
-        switch popup {
-        case .useSpoon(let action):
-            action
-        case .registerSuccess(let action):
-            action
-        case .reportSuccess(let action):
-            action
-        }
-    }
-    
     private var descriptionYOffset: CGFloat {
         switch popup {
         case .useSpoon, .registerSuccess:
@@ -151,9 +133,11 @@ extension PopupView {
             12
         }
     }
-
+    
 }
 
 #Preview {
-    PopupView(popup: .useSpoon(action: {}), isPresented: .constant(true))
+    PopupView(popup: .useSpoon, isPresented: .constant(true)) {
+        print("dd")
+    }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #26 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- popup UI 구현
- SpoonyButton 터치 영역 수정
- 사진은 임의로 넣음 ~ 

|    구현 내용    |   IPhone 16 pro   | 
| :-------------: | :----------: | 
| GIF | <img src = "https://github.com/user-attachments/assets/fc34be92-e408-4eef-b2bb-f1966b4e350e" width ="250"> | 
| GIF | <img src = "https://github.com/user-attachments/assets/a2e8ffad-bc90-4810-9744-b85e137eb8a1" width ="250"> | 
| GIF | <img src = "https://github.com/user-attachments/assets/b6bd6449-74d6-4441-bc59-0171058e9113" width ="250"> | 


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
- 사용예시
```swift
struct Home: View {
    @State private var isPresented: Bool = false
    
    var body: some View {
        VStack {
            Text("Home")
                .onTapGesture {
                    isPresented = true
                }
        }
        .popup(popup: .useSpoon(action: {print("dd")}), isPresented: $isPresented)
        
    }
}

```

- Popup이 추가될 경우 PopupType에 버튼 액션을 포함한 enum case 를 추가하고 PopupView의 extensino에서 변수 case 처리합니다.


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->
- 현재 popup, bottom sheet 같이 isPresented가 필요한 요소들이 있는데 만약 한 view에서 이런 컴포넌트가 많아진다면 네이밍을 비롯한 관리가 불편해질 것 같습니다 ! navigationManager가 존재한다면 여기서 관리해도 괜찮을 것 같은데 의견이 궁금하네요~
