### PR TITLE
[Feat] #37 - 네이버 맵 검색 기능 구현 했습니다.

### DIFF
--- a/Spoony-iOS/Info.plist
+++ b/Spoony-iOS/Info.plist
@@ -8,6 +8,10 @@
 	<string>$(ClientSecret)</string>
 	<key>NMFClientId</key>
 	<string>$(NMFClientId)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>nmap</string>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/Detail.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/Detail.swift
@@ -6,9 +6,27 @@
 //
 
 import SwiftUI
+import NMapsMap
 
 struct Detail: View {
+    
+    private var searchName = "매운집"
+    private var appName: String = "Spoony"
+    
     var body: some View {
-        Text("Detail")
+        SpoonyButton(style: .primary, size: .large, title: "샤갈 네이버", disabled: .constant(false)) {
+            let url = URL(string: "nmap://search?query=\(searchName)&appname=\(appName)")!
+            let appStoreURL = URL(string: "http://itunes.apple.com/app/id311867728?mt=8")!
+            
+            if UIApplication.shared.canOpenURL(url) {
+                UIApplication.shared.open(url)
+            } else {
+                UIApplication.shared.open(appStoreURL)
+            }
+        }
     }
+}
+
+#Preview {
+    Detail()
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #37

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->

- 앱에서 원하는 키워드를 검색하여 버튼을 누르면 네이버 지도 검색으로 가는 로직을 구현 했습니다.

|    앱 없을때    |  앱 있을때   | 
| :-------------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/c8ecff63-05d9-4a08-bffc-3c40e06b906d" width ="350"> | <img src = "https://github.com/user-attachments/assets/631cdd3a-95c0-4de7-a981-813916e6e3bc" width ="350"> |


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->

<img width="801" alt="image" src="https://github.com/user-attachments/assets/e559aac3-3529-4652-9f29-a81ce0d0ac46" />

- 공식 문서를 읽고 앱 스킴을 따라서 하면 됩니다.
```swift
let url = URL(string: "nmap://search?query=\(searchName)&appname=\(appName)")!
let appStoreURL = URL(string: "http://itunes.apple.com/app/id311867728?mt=8")!

if UIApplication.shared.canOpenURL(url) {
    UIApplication.shared.open(url)
} else {
    UIApplication.shared.open(appStoreURL)
}
```

## 📚 참고자료
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

[네이버 맵 Scheme 공식문서](https://guide.ncloud-docs.com/docs/maps-url-scheme)