### PR TITLE
[Style] 바텀시트 제스처 따라 수정

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
@@ -48,7 +48,7 @@ struct BottomSheetListItem: View {
                     )
             }
             .layoutPriority(1)
-
+            
             //Todo: 실제 이미지로 교체
             RoundedRectangle(cornerRadius: 8)
                 .fill(Color.gray.opacity(0.1))
@@ -89,7 +89,7 @@ struct BottomSheetListView: View {
     }
     
     var body: some View {
-        GeometryReader { geometry in
+        GeometryReader { _ in
             VStack(spacing: 0) {
                 // 핸들바 영역
                 VStack(spacing: 8) {
@@ -123,17 +123,17 @@ struct BottomSheetListView: View {
                                                 firstItemFrame = itemGeometry.frame(in: .named("scrollView"))
                                             }
                                         }
-                                        .onChange(of: itemGeometry.frame(in: .named("scrollView"))) { frame in
+                                        .onChange(of: itemGeometry.frame(in: .named("scrollView"))) { _, newFrame in
                                             if index == 0 {
-                                                firstItemFrame = frame
+                                                firstItemFrame = newFrame
                                                 
                                                 // 첫 번째 셀의 위치에 따라 바텀시트 상태 변경
                                                 let threshold: CGFloat = -30
-                                                if frame.minY < threshold && currentStyle == .half {
+                                                if newFrame.minY < threshold && currentStyle == .half {
                                                     withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                                         currentStyle = .full
                                                     }
-                                                } else if frame.minY > threshold && currentStyle == .full {
+                                                } else if newFrame.minY > threshold && currentStyle == .full {
                                                     withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                                         currentStyle = .half
                                                     }
@@ -145,8 +145,7 @@ struct BottomSheetListView: View {
                                 Divider()
                             }
                         }
-                        // 탭바 높이 + 추가 여백만큼 패딩 추가
-                        Color.clear.frame(height: 83) // 탭바 높이(49) + 추가 여백(34)
+                        Color.clear.frame(height: 90)
                     }
                 }
                 .coordinateSpace(name: "scrollView")

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
@@ -145,7 +145,8 @@ struct BottomSheetListView: View {
                                 Divider()
                             }
                         }
-                        Color.clear.frame(height: 83)
+                        // 탭바 높이 + 추가 여백만큼 패딩 추가
+                        Color.clear.frame(height: 83) // 탭바 높이(49) + 추가 여백(34)
                     }
                 }
                 .coordinateSpace(name: "scrollView")
@@ -162,7 +163,13 @@ struct BottomSheetListView: View {
                     }
                     .onChanged { value in
                         let translation = value.translation.height
-                        offset = translation
+                        
+                        // full 상태에서는 위로 드래그 방지 (translation이 음수일 때)
+                        if currentStyle == .full && translation < 0 {
+                            offset = 0
+                        } else {
+                            offset = translation
+                        }
                     }
                     .onEnded { value in
                         let translation = value.translation.height
@@ -199,6 +206,7 @@ struct BottomSheetListView: View {
         }
     }
 }
+
 struct ScrollOffsetPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
@@ -145,8 +145,7 @@ struct BottomSheetListView: View {
                                 Divider()
                             }
                         }
-                        // 탭바 높이만큼 추가 패딩
-                        Color.clear.frame(height: 49)
+                        Color.clear.frame(height: 83)
                     }
                 }
                 .coordinateSpace(name: "scrollView")


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #54 

## 📄 작업 내용
- 바텀시트 스크롤 영역따라 같이 올라가고 내려가기
- 하단영역 여백 추가하여 맞추기

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/cff00ba4-8057-48b1-8447-0b1af7a6251c" width ="250"> | <img src = "https://github.com/user-attachments/assets/7b6f56bd-7c8f-4eaa-ac0e-3f40ca9b1f61" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`코드 설명할 파일 이름 (ex: HomeView)`
- 어쩌구저쩌구
```swift
.background(
                                    GeometryReader { itemGeometry in
                                        Color.clear.onAppear {
                                            if index == 0 {
                                                firstItemFrame = itemGeometry.frame(in: .named("scrollView"))
                                            }
                                        }
                                        .onChange(of: itemGeometry.frame(in: .named("scrollView"))) { _, newFrame in
                                            if index == 0 {
                                                firstItemFrame = newFrame
                                                
                                                // 첫 번째 셀의 위치에 따라 바텀시트 상태 변경
                                                let threshold: CGFloat = -30
                                                if newFrame.minY < threshold && currentStyle == .half {
                                                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                                        currentStyle = .full
                                                    }
                                                } else if newFrame.minY > threshold && currentStyle == .full {
                                                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                                                        currentStyle = .half
                                                    }
                                                }
                                            }
                                        }
                                    }
                                )
                                Divider()
                            }
                        }
                        Color.clear.frame(height: 90)
```
첫 번째 셀의 위치를 지속적으로 모니터링
스크롤에 따른 셀의 위치 변화를 감지
위치에 따라 바텀시트의 상태(full/half)를 자동으로 전환


## 👀 기타 더 이야기해볼 점
현재 gif에는 16프로에서 약간 이상하게 나오는데 실제 실행시 추가 여백을 두어서 정상동작합니다.