### PR TITLE
[Fix] 텍스트 필드 로직 수정

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextEditor.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextEditor.swift
@@ -71,7 +71,7 @@ extension SpoonyTextEditor {
                         .foregroundStyle(text.isEmpty ? .gray500 : .clear)
                         .offset(x: 5.adjusted, y: 8.adjustedH)
                 }
-                .onChange(of: text) { oldValue, newValue in
+                .onChange(of: text) { _, newValue in
                     switch checkInputError(newValue) {
                     case .maximumInputError(let style):
                         errorState = .maximumInputError(style: style)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
@@ -38,7 +38,7 @@ public struct SpoonyTextField: View {
     
     // MARK: - Body
     public var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
             customTextField
             
             if let message = errorState.errorMessage, isErrorMessageVisible() {
@@ -116,9 +116,11 @@ extension SpoonyTextField {
                         }
                     }
                 case .icon:
-                    if isFocused {
+                    if !text.isEmpty {
                         Button {
-                            text = ""
+                            if let action = action {
+                                action()
+                            }
                         } label: {
                             if let icon = style.trailingIcon,
                                let size = style.iconSize {
@@ -154,6 +156,7 @@ extension SpoonyTextField {
                 .font(.caption1m)
                 .foregroundStyle(.error400)
         }
+        .padding(.top, 8)
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
@@ -32,4 +32,9 @@ extension View {
     func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
         clipShape(RoundedCorner(radius: radius, corners: corners))
     }
+    
+    // 화면 터치시 키보드를 내리기 위한 extension
+    func hideKeyboard() {
+        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #61 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 텍스트 필드 로직 변경
- 다른 화면 터치시 키보드 내리기 위한 함수
- 이제 .icon의 경우 text 지우는 함수도 action에 구현해야합니다.

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`View+`

```swift
// 코드는 이 사이에 작성하면 됩니다. 
extension View {
    func hideKeyboard() {
        UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
    }
}

사용법
최상위뷰 
.onTapGesture {
    hideKeyboard()
}
```