### PR TITLE
[Style] Navigation 디테일 수정

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -33,31 +33,31 @@ struct CustomNavigationBar: View {
     }
     
     var body: some View {
-         ZStack {
-             if style.showsBackButton {
-                 backButton
-             }
-             
-             switch style {
-             case .primary:
-                 primaryContent
-             case .search:
-                 searchContent
-             case .locationDetail:
-                 locationDetailContent
-             case .locationTitle:
-                 locationTitleContent
-             case .detail(let isLiked):
-                 detailContent(isLiked: isLiked)
-             case .detailWithChip(let count):
-                 detailWithChipContent(count: count)
-             case .searchBar:
-                 searchBarContent
-             }
-         }
-         .frame(height: 56.adjusted)
-         .background(.white)
-     }
+        ZStack {
+            if style.showsBackButton {
+                backButton
+            }
+            
+            switch style {
+            case .primary:
+                primaryContent
+            case .search:
+                searchContent
+            case .locationDetail:
+                locationDetailContent
+            case .locationTitle:
+                locationTitleContent
+            case .detail(let isLiked):
+                detailContent(isLiked: isLiked)
+            case .detailWithChip(let count):
+                detailWithChipContent(count: count)
+            case .searchBar:
+                searchBarContent
+            }
+        }
+        .frame(height: 56.adjusted)
+        .background(.white)
+    }
     
     private var backButtonView: some View {
         Button(action: onBackTapped) {
@@ -72,7 +72,7 @@ struct CustomNavigationBar: View {
         }
         .padding(.horizontal, 16)
     }
-
+    
     private var primaryContent: some View {
         HStack {
             if !title.isEmpty {
@@ -82,7 +82,7 @@ struct CustomNavigationBar: View {
             Spacer()
         }
     }
-
+    
     private var searchContent: some View {
         HStack(spacing: 12) {
             if style.showsBackButton {
@@ -134,13 +134,8 @@ struct CustomNavigationBar: View {
             
             Spacer()
             
-            Text("99+")
-                .font(.system(size: 12))
-                .foregroundColor(.white)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Color.black)
-                .cornerRadius(12)
+            LogoChip(type: .small, count: 99)
+                .padding(.trailing, 20)
         }
     }
     
@@ -159,16 +154,8 @@ struct CustomNavigationBar: View {
         HStack {
             Spacer()
             
-            HStack(spacing: 4) {
-                Text("\(count)")
-                    .font(.system(size: 14))
-                Image(.icSpoonWhite)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Color.spoonBlack)
-            .foregroundColor(Color.white)
-            .cornerRadius(16)
+            LogoChip(type: .small, count: count)
+                .padding(.trailing, 20)
         }
     }
     
@@ -224,9 +211,61 @@ struct CustomNavigationBar: View {
         }
         .padding(.horizontal, 16)
     }
-
+    
 }
 
-#Preview {
-    SearchViewTest()
+struct CustomNavigationBar_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            CustomNavigationBar(
+                style: .primary,
+                title: "Primary 스타일",
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .searchBar,
+                searchText: .constant("검색어"),
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .locationDetail,
+                title: "위치 상세",
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .locationTitle,
+                title: "홍대입구역",
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .detail(isLiked: true),
+                title: "상세 페이지",
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .detailWithChip(count: 42),
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .searchBar,
+                searchText: .constant(""),
+                onBackTapped: {}
+            )
+            .border(.gray)
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -98,6 +98,9 @@ struct CustomNavigationBar: View {
                         Text("플레이스 홀더")
                             .foregroundColor(Color(.gray600))
                     }
+                    .onSubmit {
+                        onSearchSubmit?()
+                    }
                 
                 if !searchText.isEmpty {
                     Button(action: { searchText = "" }) {
@@ -197,6 +200,9 @@ struct CustomNavigationBar: View {
                     .placeholder(when: searchText.isEmpty) {
                         Text("마포구,성수동,강남역")
                             .foregroundColor(Color(.gray600))
+                    }
+                    .onSubmit {
+                        onSearchSubmit?()
                     }
                 
                 if !searchText.isEmpty {

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -51,6 +51,8 @@ struct CustomNavigationBar: View {
                  detailContent(isLiked: isLiked)
              case .detailWithChip(let count):
                  detailWithChipContent(count: count)
+             case .searchBar:
+                 searchBarContent
              }
          }
          .frame(height: 56.adjusted)
@@ -180,4 +182,48 @@ struct CustomNavigationBar: View {
         }
         .padding(.horizontal, 16)
     }
+    
+    private var searchBarContent: some View {
+        HStack(spacing: 12) {
+            if style.showsBackButton {
+                backButtonView
+            }
+            
+            HStack(spacing: 8) {
+                Image(.icSearchGray600)
+                
+                TextField("", text: $searchText)
+                    .frame(height: 44.adjusted)
+                    .placeholder(when: searchText.isEmpty) {
+                        Text("검색어를 입력하세요")
+                            .foregroundColor(Color(.gray600))
+                    }
+                
+                if !searchText.isEmpty {
+                    Button(action: { searchText = "" }) {
+                        Image(.icCloseGray400)
+                            .foregroundColor(Color(.gray600))
+                    }
+                }
+                
+                if let onSearchSubmit = onSearchSubmit {
+                    Button(action: onSearchSubmit) {
+                        Text("검색")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(Color.spoonBlack)
+                            .cornerRadius(8)
+                    }
+                }
+            }
+            .padding(.horizontal, 12)
+            .background(Color(.gray100))
+            .cornerRadius(8)
+            .frame(height: 44.adjusted)
+        }
+        .padding(.horizontal, 16)
+    }
+
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -39,20 +39,20 @@ struct CustomNavigationBar: View {
             }
             
             switch style {
-            case .primary:
-                primaryContent
+//            case .primary:
+//                primary
             case .search:
-                searchContent
-            case .locationDetail:
-                locationDetailContent
-            case .locationTitle:
-                locationTitleContent
-            case .detail(let isLiked):
-                detailContent(isLiked: isLiked)
-            case .detailWithChip(let count):
-                detailWithChipContent(count: count)
+                search
             case .searchBar:
-                searchBarContent
+                searchBar
+            case .locationTitle:
+                locationTitle
+            case .locationDetail:
+                locationDetail
+            case .detail(let isLiked):
+                detail(isLiked: isLiked)
+            case .detailWithChip(let count):
+                detailWithChip(count: count)
             }
         }
         .frame(height: 56.adjusted)
@@ -73,19 +73,19 @@ struct CustomNavigationBar: View {
         .padding(.horizontal, 16)
     }
     
-    private var primaryContent: some View {
-        HStack {
-            if !title.isEmpty {
-                Text(title)
-                    .font(.title2b)
-            }
-            Spacer()
-        }
-    }
+//    private var primary: some View {
+//        HStack {
+//            if !title.isEmpty {
+//                Text(title)
+//                    .font(.title2b)
+//            }
+//            Spacer()
+//        }
+//    }
     
-    private var searchContent: some View {
+    private var search: some View {
         HStack(spacing: 12) {
-            if style.showsBackButton {
+            if case .search(let showBackButton) = style, showBackButton {
                 backButtonView
             }
             
@@ -120,7 +120,7 @@ struct CustomNavigationBar: View {
         .padding(.horizontal, 16)
     }
     
-    private var locationDetailContent: some View {
+    private var locationDetail: some View {
         HStack {
             Button(action: {}) {
                 HStack {
@@ -139,7 +139,7 @@ struct CustomNavigationBar: View {
         }
     }
     
-    private func detailContent(isLiked: Bool) -> some View {
+    private func detail(isLiked: Bool) -> some View {
         HStack {
             Spacer()
             Text(title)
@@ -150,7 +150,7 @@ struct CustomNavigationBar: View {
         }
     }
     
-    private func detailWithChipContent(count: Int) -> some View {
+    private func detailWithChip(count: Int) -> some View {
         HStack {
             Spacer()
             
@@ -159,7 +159,7 @@ struct CustomNavigationBar: View {
         }
     }
     
-    private var locationTitleContent: some View {
+    private var locationTitle: some View {
         HStack {
             Text(title.isEmpty ? "홍대입구역" : title)
                 .font(.title2b)
@@ -173,7 +173,7 @@ struct CustomNavigationBar: View {
         .padding(.horizontal, 16)
     }
     
-    private var searchBarContent: some View {
+    private var searchBar: some View {
         HStack(spacing: 12) {
             if style.showsBackButton {
                 backButtonView
@@ -198,7 +198,6 @@ struct CustomNavigationBar: View {
                             .foregroundColor(Color(.gray600))
                     }
                 }
-                
             }
             .padding(.horizontal, 12)
             .background(Color(.white))
@@ -211,21 +210,20 @@ struct CustomNavigationBar: View {
         }
         .padding(.horizontal, 16)
     }
-    
 }
 
 struct CustomNavigationBar_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
-            CustomNavigationBar(
-                style: .primary,
-                title: "Primary 스타일",
-                onBackTapped: {}
-            )
-            .border(.gray)
+//            CustomNavigationBar(
+//                style: .primary,
+//                title: "Primary 스타일",
+//                onBackTapped: {}
+//            )
+//            .border(.gray)
             
             CustomNavigationBar(
-                style: .searchBar,
+                style: .search(showBackButton: true),
                 searchText: .constant("검색어"),
                 onBackTapped: {}
             )

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -39,20 +39,20 @@ struct CustomNavigationBar: View {
             }
             
             switch style {
-//            case .primary:
-//                primary
-            case .search:
-                search
-            case .searchBar:
-                searchBar
-            case .locationTitle:
-                locationTitle
+            case .searchContent:
+                searchContent
             case .locationDetail:
                 locationDetail
+            case .locationTitle:
+                locationTitle
             case .detail(let isLiked):
                 detail(isLiked: isLiked)
             case .detailWithChip(let count):
                 detailWithChip(count: count)
+            case .search:
+                searchBar
+            case .searchBar:
+                searchBar
             }
         }
         .frame(height: 56.adjusted)
@@ -73,49 +73,31 @@ struct CustomNavigationBar: View {
         .padding(.horizontal, 16)
     }
     
-//    private var primary: some View {
-//        HStack {
-//            if !title.isEmpty {
-//                Text(title)
-//                    .font(.title2b)
-//            }
-//            Spacer()
-//        }
-//    }
-    
-    private var search: some View {
+    private var searchContent: some View {
         HStack(spacing: 12) {
-            if case .search(let showBackButton) = style, showBackButton {
-                backButtonView
-            }
+            LogoChip(type: .small, count: 10)
             
             HStack(spacing: 8) {
                 Image(.icSearchGray600)
                 
-                TextField("", text: $searchText)
-                    .frame(height: 44.adjusted)
-                    .placeholder(when: searchText.isEmpty) {
-                        Text("플레이스 홀더")
-                            .foregroundColor(Color(.gray600))
-                    }
-                    .onSubmit {
-                        onSearchSubmit?()
-                    }
-                
-                if !searchText.isEmpty {
-                    Button(action: { searchText = "" }) {
-                        Image(.icCloseGray400)
-                            .foregroundColor(Color(.gray600))
-                    }
-                }
+                Text("오늘은 어디서 먹어볼까요?")
+                    .foregroundColor(Color(.gray500))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.body2m)
             }
             .padding(.horizontal, 12)
-            .background(Color.white)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color(.gray600), lineWidth: 1)
+            .frame(height: 44.adjustedH)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.white)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color(.gray200), lineWidth: 1)
+                    )
             )
-            .frame(height: 44.adjusted)
+            .onTapGesture {
+                onSearchSubmit?()
+            }
         }
         .padding(.horizontal, 16)
     }
@@ -125,7 +107,7 @@ struct CustomNavigationBar: View {
             Button(action: {}) {
                 HStack {
                     Text(title)
-                        .font(.title2b)
+                        .font(.title2sb)
                         .foregroundColor(.spoonBlack)
                     Image(.icArrowRightGray700)
                 }
@@ -137,6 +119,20 @@ struct CustomNavigationBar: View {
             LogoChip(type: .small, count: 99)
                 .padding(.trailing, 20)
         }
+    }
+    
+    private var locationTitle: some View {
+        HStack {
+            Text(title.isEmpty ? "홍대입구역" : title)
+                .font(.title2b)
+                .foregroundColor(.black)
+            Spacer()
+            Button(action: onBackTapped) {
+                Image(.icCloseGray400)
+                    .foregroundColor(.gray)
+            }
+        }
+        .padding(.horizontal, 16)
     }
     
     private func detail(isLiked: Bool) -> some View {
@@ -157,20 +153,6 @@ struct CustomNavigationBar: View {
             LogoChip(type: .small, count: count)
                 .padding(.trailing, 20)
         }
-    }
-    
-    private var locationTitle: some View {
-        HStack {
-            Text(title.isEmpty ? "홍대입구역" : title)
-                .font(.title2b)
-                .foregroundColor(.black)
-            Spacer()
-            Button(action: onBackTapped) {
-                Image(.icCloseGray400)
-                    .foregroundColor(.gray)
-            }
-        }
-        .padding(.horizontal, 16)
     }
     
     private var searchBar: some View {
@@ -215,15 +197,8 @@ struct CustomNavigationBar: View {
 struct CustomNavigationBar_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
-//            CustomNavigationBar(
-//                style: .primary,
-//                title: "Primary 스타일",
-//                onBackTapped: {}
-//            )
-//            .border(.gray)
-            
             CustomNavigationBar(
-                style: .search(showBackButton: true),
+                style: .searchContent,
                 searchText: .constant("검색어"),
                 onBackTapped: {}
             )

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -195,7 +195,7 @@ struct CustomNavigationBar: View {
                 TextField("", text: $searchText)
                     .frame(height: 44.adjusted)
                     .placeholder(when: searchText.isEmpty) {
-                        Text("검색어를 입력하세요")
+                        Text("마포구,성수동,강남역")
                             .foregroundColor(Color(.gray600))
                     }
                 
@@ -206,24 +206,21 @@ struct CustomNavigationBar: View {
                     }
                 }
                 
-                if let onSearchSubmit = onSearchSubmit {
-                    Button(action: onSearchSubmit) {
-                        Text("검색")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(Color.spoonBlack)
-                            .cornerRadius(8)
-                    }
-                }
             }
             .padding(.horizontal, 12)
-            .background(Color(.gray100))
-            .cornerRadius(8)
+            .background(Color(.white))
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(.gray400), lineWidth: 1)
+            )
+            .cornerRadius(10)
             .frame(height: 44.adjusted)
         }
         .padding(.horizontal, 16)
     }
 
+}
+
+#Preview {
+    SearchViewTest()
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -13,6 +13,7 @@ enum NavigationBarStyle {
     
     // 검색 관련
     case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
+    case searchBar
     
     // 위치 관련
     case locationTitle    // 위치 제목만 표시

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -9,19 +9,20 @@ import SwiftUI
 
 enum NavigationBarStyle {
     // 기본 네비게이션
-    case primary
+    //지도뷰 에 왼쪽 타이틀 오른쪽에 X버튼 있는뷰 (검색상세로 넘어갈때)
+   //case primary
     
     // 검색 관련
     case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
     case searchBar
     
     // 위치 관련
-    case locationTitle    // 위치 제목만 표시
-    case locationDetail   // 위치 상세 정보 표시
+    case locationTitle    // 위치 제목 + 오른쪽 X 버튼
+    case locationDetail   // 탐색 리스트 - 현위치 + > + 오른쪽 칩 아이콘
     
     // 상세 화면 관련
     case detail(isLiked: Bool)         // 좋아요 기능이 있는 상세
-    case detailWithChip(count: Int)    // 카운트 칩이 있는 상세
+    case detailWithChip(count: Int)    // < + 오른쪽 칩 (가운데 타이틀 없음)
     
     // 백 버튼 표시 여부
     var showsBackButton: Bool {

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 
 enum NavigationBarStyle {
-    // 기본 네비게이션
-    //지도뷰 에 왼쪽 타이틀 오른쪽에 X버튼 있는뷰 (검색상세로 넘어갈때)
-   //case primary
     
     // 검색 관련
     case searchContent //지도에서 왼쪽에 칩 있는거

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -13,6 +13,7 @@ enum NavigationBarStyle {
    //case primary
     
     // 검색 관련
+    case searchContent //지도에서 왼쪽에 칩 있는거
     case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
     case searchBar
     
@@ -21,13 +22,13 @@ enum NavigationBarStyle {
     case locationDetail   // 탐색 리스트 - 현위치 + > + 오른쪽 칩 아이콘
     
     // 상세 화면 관련
-    case detail(isLiked: Bool)         // 좋아요 기능이 있는 상세
+    case detail(isLiked: Bool)         // < + 가운데 타이틀 사용 (신고하기)
     case detailWithChip(count: Int)    // < + 오른쪽 칩 (가운데 타이틀 없음)
     
     // 백 버튼 표시 여부
     var showsBackButton: Bool {
         switch self {
-        case .locationDetail, .locationTitle:
+        case .locationDetail, .locationTitle, .searchContent:
             return false
         case .search(let showBackButton):
             return showBackButton

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
@@ -1,0 +1,31 @@
+//
+//  SearchViewTest.swift
+//  Spoony-iOS
+//
+//  Created by 이지훈 on 1/16/25.
+//
+
+import SwiftUI
+
+struct SearchViewTest: View {
+   @State private var searchText = ""
+   
+   var body: some View {
+       VStack(spacing: 0) {
+           CustomNavigationBar(
+               style: .searchBar,
+               searchText: $searchText,
+               onBackTapped: {},
+               onSearchSubmit: {
+                   print("Search submitted: \(searchText)")
+               }
+           )
+           
+           Spacer()
+       }
+   }
+}
+
+#Preview {
+   SearchViewTest()
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
@@ -9,6 +9,15 @@ import SwiftUI
 
 struct SearchViewTest: View {
     @State private var searchText = ""
+    @State private var searchResults: [SearchResult] = []
+    @State private var searchState: SearchState = .empty
+    @State private var recentSearches = ["홍대입구역", "성수동", "망원동"]
+    
+    enum SearchState {
+        case empty
+        case typing
+        case searched
+    }
     
     var body: some View {
         ZStack {
@@ -17,13 +26,45 @@ struct SearchViewTest: View {
                     style: .searchBar,
                     searchText: $searchText,
                     onBackTapped: {},
-                    onSearchSubmit: {
-                        print("Search submitted: \(searchText)")
-                    }
+                    onSearchSubmit: handleSearch
                 )
+                
+                switch searchState {
+                case .empty:
+                    emptyStateView
+                case .typing:
+                    recentSearchesView
+                case .searched:
+                    // 검색 결과 리스트
+                    List {
+                        ForEach(getFilteredResults(), id: \.id) { result in
+                            SearchResultRow(result: result)
+                        }
+                    }
+                    .listStyle(PlainListStyle())
+                }
                 
                 Spacer()
             }
+        }
+        .onChange(of: searchText) { newValue in
+            if newValue.isEmpty {
+                searchState = .empty
+            } else if searchState != .searched {
+                searchState = .typing
+            }
+        }
+    }
+    
+    private func handleSearch() {
+        guard !searchText.isEmpty else { return }
+        searchState = .searched
+        updateSearchResults()
+    }
+    
+    private var emptyStateView: some View {
+        VStack {
+            Spacer()
             VStack(spacing: 8) {
                 Rectangle()
                     .fill(Color(.gray200))
@@ -34,8 +75,95 @@ struct SearchViewTest: View {
                     .font(.system(size: 16))
                     .foregroundColor(Color(.gray600))
             }
-            .offset(y: -100)
+            Spacer()
+                .frame(height: 100)
         }
+    }
+    
+    private var recentSearchesView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text("최근 검색")
+                    .font(.system(size: 16, weight: .medium))
+                Spacer()
+                Button("전체삭제") {
+                    recentSearches.removeAll()
+                }
+                .font(.system(size: 14))
+                .foregroundColor(Color(.gray600))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            
+            VStack(alignment: .leading, spacing: 0) {
+                ForEach(recentSearches, id: \.self) { search in
+                    HStack {
+                        Text(search)
+                            .font(.system(size: 16))
+                        Spacer()
+                        Button(action: {
+                            if let index = recentSearches.firstIndex(of: search) {
+                                recentSearches.remove(at: index)
+                            }
+                        }) {
+                            Image(.icCloseGray400)
+                        }
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 12)
+                }
+            }
+        }
+    }
+    
+    private func updateSearchResults() {
+        if !searchText.isEmpty {
+            searchResults = [
+                SearchResult(title: "\(searchText)구역", address: "서울 마포구 양화로 160 \(searchText)구역"),
+                SearchResult(title: "\(searchText)동", address: "서울 마포구 양화로 160 \(searchText)구역"),
+                SearchResult(title: "\(searchText)구", address: "서울 마포구 양화로 160 \(searchText)구역")
+            ]
+            
+            if !recentSearches.contains(searchText) {
+                recentSearches.insert(searchText, at: 0)
+                if recentSearches.count > 5 {
+                    recentSearches.removeLast()
+                }
+            }
+        } else {
+            searchResults.removeAll()
+        }
+    }
+    
+    private func getFilteredResults() -> [SearchResult] {
+        return searchResults
+    }
+}
+
+struct SearchResult: Identifiable {
+    let id = UUID()
+    let title: String
+    let address: String
+}
+
+struct SearchResultRow: View {
+    let result: SearchResult
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                Image(.icPinGray600)
+                Text(result.title)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(.black)
+            }
+            
+            Text(result.address)
+                .font(.system(size: 14))
+                .foregroundColor(Color(.gray600))
+                .padding(.leading, 28)
+        }
+        .padding(.vertical, 8)
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
@@ -7,6 +7,13 @@
 
 import SwiftUI
 
+// 검색 결과를 위한 모델
+struct SearchResult: Identifiable {
+    let id = UUID()
+    let title: String
+    let address: String
+}
+
 struct SearchViewTest: View {
     @State private var searchText = ""
     @State private var searchResults: [SearchResult] = []
@@ -31,11 +38,14 @@ struct SearchViewTest: View {
                 
                 switch searchState {
                 case .empty:
-                    emptyStateView
+                    if recentSearches.isEmpty {
+                        emptyStateView
+                    } else {
+                        recentSearchesView
+                    }
                 case .typing:
                     recentSearchesView
                 case .searched:
-                    // 검색 결과 리스트
                     List {
                         ForEach(getFilteredResults(), id: \.id) { result in
                             SearchResultRow(result: result)
@@ -140,12 +150,7 @@ struct SearchViewTest: View {
     }
 }
 
-struct SearchResult: Identifiable {
-    let id = UUID()
-    let title: String
-    let address: String
-}
-
+// 검색 결과 행을 위한 뷰
 struct SearchResultRow: View {
     let result: SearchResult
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Search/SearchViewTest.swift
@@ -8,24 +8,37 @@
 import SwiftUI
 
 struct SearchViewTest: View {
-   @State private var searchText = ""
-   
-   var body: some View {
-       VStack(spacing: 0) {
-           CustomNavigationBar(
-               style: .searchBar,
-               searchText: $searchText,
-               onBackTapped: {},
-               onSearchSubmit: {
-                   print("Search submitted: \(searchText)")
-               }
-           )
-           
-           Spacer()
-       }
-   }
+    @State private var searchText = ""
+    
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                CustomNavigationBar(
+                    style: .searchBar,
+                    searchText: $searchText,
+                    onBackTapped: {},
+                    onSearchSubmit: {
+                        print("Search submitted: \(searchText)")
+                    }
+                )
+                
+                Spacer()
+            }
+            VStack(spacing: 8) {
+                Rectangle()
+                    .fill(Color(.gray200))
+                    .frame(width: 200, height: 200)
+                    .padding(.bottom, 12)
+                
+                Text("구체적인 장소를 검색해 보세요")
+                    .font(.system(size: 16))
+                    .foregroundColor(Color(.gray600))
+            }
+            .offset(y: -100)
+        }
+    }
 }
 
 #Preview {
-   SearchViewTest()
+    SearchViewTest()
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/SpoonyTabView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/SpoonyTabView.swift
@@ -23,7 +23,7 @@ struct SpoonyTabView: View {
                     switch tab {
                     case .map:
                         NavigationStack(path: $navigationManager.mapPath) {
-                            Home()
+                            SearchViewTest()
                                 .navigationDestination(for: ViewType.self) { view in
                                     navigationManager.build(view)
                                 }


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #66 

## 📄 작업 내용
- chip 이미지를 포함한 모든 디테일을 수정했습니다.

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`코드 설명할 파일 이름 (ex: HomeView)`
- 어쩌구저쩌구
```swift

import SwiftUI

enum NavigationBarStyle {
    // 기본 네비게이션
    //지도뷰 에 왼쪽 타이틀 오른쪽에 X버튼 있는뷰 (검색상세로 넘어갈때)
   //case primary
    
    // 검색 관련
    case searchContent //지도에서 왼쪽에 칩 있는거
    case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
    case searchBar
    
    // 위치 관련
    case locationTitle    // 위치 제목 + 오른쪽 X 버튼
    case locationDetail   // 탐색 리스트 - 현위치 + > + 오른쪽 칩 아이콘
    
    // 상세 화면 관련
    case detail(isLiked: Bool)         // < + 가운데 타이틀 사용 (신고하기)
    case detailWithChip(count: Int)    // < + 오른쪽 칩 (가운데 타이틀 없음)
    
    // 백 버튼 표시 여부
    var showsBackButton: Bool {
        switch self {
        case .locationDetail, .locationTitle, .searchContent:
            return false
        case .search(let showBackButton):
            return showBackButton
        default:
            return true
        }
    }
}
```

## 📚 참고자료

## 👀 기타 더 이야기해볼 점
주석적었습니다 잘 사용해주세요