### PR TITLE
[Style] 네비게이션 디테일 UI 추가

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -10,17 +10,17 @@ import SwiftUI
 struct CustomNavigationBar: View {
     @Binding var searchText: String
     
-    let style: NavigationBarStyle
-    let title: String
-    let onBackTapped: () -> Void
-    let onSearchSubmit: (() -> Void)?
-    let onLikeTapped: (() -> Void)?
+    private let style: NavigationBarStyle
+    private let title: String?
+    private let onBackTapped: (() -> Void)?
+    private let onSearchSubmit: (() -> Void)?
+    private let onLikeTapped: (() -> Void)?
     
     init(
         style: NavigationBarStyle,
         title: String = "",
         searchText: Binding<String> = .constant(""),
-        onBackTapped: @escaping () -> Void,
+        onBackTapped: (() -> Void)? = nil,
         onSearchSubmit: (() -> Void)? = nil,
         onLikeTapped: (() -> Void)? = nil
     ) {
@@ -45,8 +45,8 @@ struct CustomNavigationBar: View {
                 locationDetail
             case .locationTitle:
                 locationTitle
-            case .detail(let isLiked):
-                detail(isLiked: isLiked)
+            case .detail:
+                detail
             case .detailWithChip(let count):
                 detailWithChip(count: count)
             case .search:
@@ -60,9 +60,10 @@ struct CustomNavigationBar: View {
     }
     
     private var backButtonView: some View {
-        Button(action: onBackTapped) {
-            Image(.icArrowLeftGray700)
-        }
+        Image(.icArrowLeftGray700)
+            .onTapGesture {
+                onBackTapped?()
+            }
     }
     
     private var backButton: some View {
@@ -106,7 +107,7 @@ struct CustomNavigationBar: View {
         HStack {
             Button(action: {}) {
                 HStack {
-                    Text(title)
+                    Text(title ?? "홍대입구역")
                         .font(.title2sb)
                         .foregroundStyle(.spoonBlack)
                     Image(.icArrowRightGray700)
@@ -123,22 +124,25 @@ struct CustomNavigationBar: View {
     
     private var locationTitle: some View {
         HStack {
+            let title = title ?? ""
             Text(title.isEmpty ? "홍대입구역" : title)
                 .font(.title2b)
                 .foregroundStyle(.spoonBlack)
             Spacer()
-            Button(action: onBackTapped) {
-                Image(.icCloseGray400)
-                    .foregroundStyle(.gray400)
-            }
+            Image(.icCloseGray400)
+                .foregroundStyle(.gray400)
+                .onTapGesture {
+                    onBackTapped?()
+                }
         }
+        
         .padding(.horizontal, 16)
     }
     
-    private func detail(isLiked: Bool) -> some View {
+    private var detail: some View { 
         HStack {
             Spacer()
-            Text(title)
+            Text(title ?? "홍대")
                 .font(.title2b)
                 .multilineTextAlignment(.center)
                 .lineLimit(1)
@@ -219,7 +223,7 @@ struct CustomNavigationBar_Previews: PreviewProvider {
             .border(.gray)
             
             CustomNavigationBar(
-                style: .detail(isLiked: true),
+                style: .detail,
                 title: "상세 페이지",
                 onBackTapped: {}
             )

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -10,12 +10,12 @@ import SwiftUI
 struct CustomNavigationBar: View {
     @Binding var searchText: String
     
-    let style: NavigationBarStyle
-    let title: String
-    let onBackTapped: (() -> Void)?
-    let onSearchSubmit: (() -> Void)?
-    let onLikeTapped: (() -> Void)?
-    let onLocationTapped: (() -> Void)?
+    private let style: NavigationBarStyle
+    private let title: String
+    private let onBackTapped: (() -> Void)?
+    private let onSearchSubmit: (() -> Void)?
+    private let onLikeTapped: (() -> Void)?
+    private let onLocationTapped: (() -> Void)?
     
     init(
         style: NavigationBarStyle,
@@ -42,17 +42,15 @@ struct CustomNavigationBar: View {
              }
              
              switch style {
-             case .primary:
-                 primaryContent
-             case .search:
+             case .navTopSearchNormalDefault:
                  searchContent
-             case .locationDetail:
+             case .navTopPrimaryTwoLeft:
                  locationDetailContent
-             case .locationTitle:
+             case .navTopPrimaryOneLeft:
                  locationTitleContent
-             case .detail(let isLiked):
+             case .navTopPrimaryOneCenter(let isLiked):
                  detailContent(isLiked: isLiked)
-             case .detailWithChip(let count):
+             case .navTopPrimaryOneChip(let count):
                  detailWithChipContent(count: count)
              }
          }
@@ -182,5 +180,45 @@ struct CustomNavigationBar: View {
             }
         }
         .padding(.horizontal, 16)
+    }
+}
+
+struct CustomNavigationBar_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            CustomNavigationBar(
+                style: .navTopPrimaryOneCenter(isLiked: true),
+                title: "Primary 스타일"
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .navTopSearchNormalDefault(showBackButton: true),
+                searchText: .constant("검색어")
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .navTopPrimaryTwoLeft,
+                title: "위치 상세",
+                onLocationTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .navTopPrimaryOneLeft,
+                title: "홍대입구역",
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .navTopPrimaryOneChip(count: 42),
+                onBackTapped: {}
+            )
+            .border(.gray)
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -10,21 +10,19 @@ import SwiftUI
 struct CustomNavigationBar: View {
     @Binding var searchText: String
     
-    private let style: NavigationBarStyle
-    private let title: String
-    private let onBackTapped: (() -> Void)?
-    private let onSearchSubmit: (() -> Void)?
-    private let onLikeTapped: (() -> Void)?
-    private let onLocationTapped: (() -> Void)?
+    let style: NavigationBarStyle
+    let title: String
+    let onBackTapped: () -> Void
+    let onSearchSubmit: (() -> Void)?
+    let onLikeTapped: (() -> Void)?
     
     init(
         style: NavigationBarStyle,
         title: String = "",
         searchText: Binding<String> = .constant(""),
-        onBackTapped: (() -> Void)? = nil,
+        onBackTapped: @escaping () -> Void,
         onSearchSubmit: (() -> Void)? = nil,
-        onLikeTapped: (() -> Void)? = nil,
-        onLocationTapped: (() -> Void)? = nil
+        onLikeTapped: (() -> Void)? = nil
     ) {
         self.style = style
         self.title = title
@@ -32,34 +30,37 @@ struct CustomNavigationBar: View {
         self.onBackTapped = onBackTapped
         self.onSearchSubmit = onSearchSubmit
         self.onLikeTapped = onLikeTapped
-        self.onLocationTapped = onLocationTapped
     }
     
     var body: some View {
-         ZStack {
-             if style.showsBackButton {
-                 backButton
-             }
-             
-             switch style {
-             case .navTopSearchNormalDefault:
-                 searchContent
-             case .navTopPrimaryTwoLeft:
-                 locationDetailContent
-             case .navTopPrimaryOneLeft:
-                 locationTitleContent
-             case .navTopPrimaryOneCenter(let isLiked):
-                 detailContent(isLiked: isLiked)
-             case .navTopPrimaryOneChip(let count):
-                 detailWithChipContent(count: count)
-             }
-         }
-         .frame(height: 56.adjusted)
-         .background(.white)
-     }
+        ZStack {
+            if style.showsBackButton {
+                backButton
+            }
+            
+            switch style {
+            case .searchContent:
+                searchContent
+            case .locationDetail:
+                locationDetail
+            case .locationTitle:
+                locationTitle
+            case .detail(let isLiked):
+                detail(isLiked: isLiked)
+            case .detailWithChip(let count):
+                detailWithChip(count: count)
+            case .search:
+                searchBar
+            case .searchBar:
+                searchBar
+            }
+        }
+        .frame(height: 56.adjusted)
+        .background(.white)
+    }
     
     private var backButtonView: some View {
-        Button(action: onBackTapped ?? { print("error") }) {
+        Button(action: onBackTapped) {
             Image(.icArrowLeftGray700)
         }
     }
@@ -71,18 +72,90 @@ struct CustomNavigationBar: View {
         }
         .padding(.horizontal, 16)
     }
-
-    private var primaryContent: some View {
-        HStack {
-            if !title.isEmpty {
-                Text(title)
-                    .font(.title2b)
+    
+    private var searchContent: some View {
+        HStack(spacing: 12) {
+            LogoChip(type: .small, count: 10)
+            
+            HStack(spacing: 8) {
+                Image(.icSearchGray600)
+                
+                Text("오늘은 어디서 먹어볼까요?")
+                    .foregroundStyle(.gray500)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.body2m)
             }
+            .padding(.horizontal, 12)
+            .frame(height: 44.adjustedH)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color.white)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(Color(.gray200), lineWidth: 1)
+                    )
+            )
+            .onTapGesture {
+                onSearchSubmit?()
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    private var locationDetail: some View {
+        HStack {
+            Button(action: {}) {
+                HStack {
+                    Text(title)
+                        .font(.title2sb)
+                        .foregroundStyle(.spoonBlack)
+                    Image(.icArrowRightGray700)
+                }
+            }
+            .padding(.leading, 16)
+            
+            Spacer()
+            
+            LogoChip(type: .small, count: 99)
+                .padding(.trailing, 20)
+        }
+    }
+    
+    private var locationTitle: some View {
+        HStack {
+            Text(title.isEmpty ? "홍대입구역" : title)
+                .font(.title2b)
+                .foregroundStyle(.spoonBlack)
+            Spacer()
+            Button(action: onBackTapped) {
+                Image(.icCloseGray400)
+                    .foregroundStyle(.gray)
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    private func detail(isLiked: Bool) -> some View {
+        HStack {
+            Spacer()
+            Text(title)
+                .font(.title2b)
+                .multilineTextAlignment(.center)
+                .lineLimit(1)
             Spacer()
         }
     }
-
-    private var searchContent: some View {
+    
+    private func detailWithChip(count: Int) -> some View {
+        HStack {
+            Spacer()
+            
+            LogoChip(type: .small, count: count)
+                .padding(.trailing, 20)
+        }
+    }
+    
+    private var searchBar: some View {
         HStack(spacing: 12) {
             if style.showsBackButton {
                 backButtonView
@@ -94,90 +167,28 @@ struct CustomNavigationBar: View {
                 TextField("", text: $searchText)
                     .frame(height: 44.adjusted)
                     .placeholder(when: searchText.isEmpty) {
-                        Text("플레이스 홀더")
-                            .foregroundColor(Color(.gray600))
+                        Text("마포구,성수동,강남역")
+                            .foregroundStyle(.gray600)
+                    }
+                    .onSubmit {
+                        onSearchSubmit?()
                     }
                 
                 if !searchText.isEmpty {
                     Button(action: { searchText = "" }) {
                         Image(.icCloseGray400)
-                            .foregroundColor(Color(.gray600))
+                            .foregroundStyle(.gray600)
                     }
                 }
             }
             .padding(.horizontal, 12)
-            .background(Color.white)
+            .background(Color(.white))
             .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(Color(.gray600), lineWidth: 1)
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(.gray400), lineWidth: 1)
             )
+            .cornerRadius(10)
             .frame(height: 44.adjusted)
-        }
-        .padding(.horizontal, 16)
-    }
-    
-    private var locationDetailContent: some View {
-        HStack {
-            Button(action: onLocationTapped ?? { print("error") }) {
-                HStack {
-                    Text(title)
-                        .font(.title2b)
-                        .foregroundColor(.spoonBlack)
-                    Image(.icArrowRightGray700)
-                }
-            }
-            .padding(.leading, 16)
-            
-            Spacer()
-            
-            Text("99+")
-                .font(.system(size: 12))
-                .foregroundColor(.white)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(Color.black)
-                .cornerRadius(12)
-        }
-    }
-    
-    private func detailContent(isLiked: Bool) -> some View {
-        HStack {
-            Spacer()
-            Text(title)
-                .font(.title2b)
-                .multilineTextAlignment(.center)
-                .lineLimit(1)
-            Spacer()
-        }
-    }
-    
-    private func detailWithChipContent(count: Int) -> some View {
-        HStack {
-            Spacer()
-            
-            HStack(spacing: 4) {
-                Text("\(count)")
-                    .font(.system(size: 14))
-                Image(.icSpoonWhite)
-            }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Color.spoonBlack)
-            .foregroundColor(Color.white)
-            .cornerRadius(16)
-        }
-    }
-    
-    private var locationTitleContent: some View {
-        HStack {
-            Text(title.isEmpty ? "홍대입구역" : title)
-                .font(.title2b)
-                .foregroundColor(.black)
-            Spacer()
-            Button(action: onBackTapped ?? { print("error") }) {
-                Image(.icCloseGray400)
-                    .foregroundColor(.gray)
-            }
         }
         .padding(.horizontal, 16)
     }
@@ -187,33 +198,42 @@ struct CustomNavigationBar_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 20) {
             CustomNavigationBar(
-                style: .navTopPrimaryOneCenter(isLiked: true),
-                title: "Primary 스타일"
+                style: .searchContent,
+                searchText: .constant("검색어"),
+                onBackTapped: {}
             )
             .border(.gray)
             
             CustomNavigationBar(
-                style: .navTopSearchNormalDefault(showBackButton: true),
-                searchText: .constant("검색어")
-            )
-            .border(.gray)
-            
-            CustomNavigationBar(
-                style: .navTopPrimaryTwoLeft,
+                style: .locationDetail,
                 title: "위치 상세",
-                onLocationTapped: {}
+                onBackTapped: {}
             )
             .border(.gray)
             
             CustomNavigationBar(
-                style: .navTopPrimaryOneLeft,
+                style: .locationTitle,
                 title: "홍대입구역",
                 onBackTapped: {}
             )
             .border(.gray)
             
             CustomNavigationBar(
-                style: .navTopPrimaryOneChip(count: 42),
+                style: .detail(isLiked: true),
+                title: "상세 페이지",
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .detailWithChip(count: 42),
+                onBackTapped: {}
+            )
+            .border(.gray)
+            
+            CustomNavigationBar(
+                style: .searchBar,
+                searchText: .constant(""),
                 onBackTapped: {}
             )
             .border(.gray)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -73,19 +73,93 @@ struct CustomNavigationBar: View {
         .padding(.horizontal, 16)
     }
     
-    private var primaryContent: some View {
-        HStack {
-            if !title.isEmpty {
-                Text(title)
-                    .font(.title2b)
+    private var searchContent: some View {
+        HStack(spacing: 12) {
+            LogoChip(type: .small, count: 10)
+            
+            HStack(spacing: 8) {
+                Image(.icSearchGray600)
+                
+                Text("오늘은 어디서 먹어볼까요?")
+                    .foregroundStyle(.gray500)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .font(.body2m)
             }
+            .padding(.horizontal, 12)
+            .frame(height: 44.adjustedH)
+            .background(
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(.white)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .strokeBorder(.gray200)
+                    )
+            )
+            .onTapGesture {
+                onSearchSubmit?()
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    private var locationDetail: some View {
+        HStack {
+            Button(action: {}) {
+                HStack {
+                    Text(title)
+                        .font(.title2sb)
+                        .foregroundStyle(.spoonBlack)
+                    Image(.icArrowRightGray700)
+                }
+            }
+            .padding(.leading, 16)
+            
+            Spacer()
+            
+            LogoChip(type: .small, count: 99)
+                .padding(.trailing, 20)
+        }
+    }
+    
+    private var locationTitle: some View {
+        HStack {
+            Text(title.isEmpty ? "홍대입구역" : title)
+                .font(.title2b)
+                .foregroundStyle(.spoonBlack)
+            Spacer()
+            Button(action: onBackTapped) {
+                Image(.icCloseGray400)
+                    .foregroundStyle(.gray400)
+            }
+        }
+        .padding(.horizontal, 16)
+    }
+    
+    private func detail(isLiked: Bool) -> some View {
+        HStack {
+            Spacer()
+            Text(title)
+                .font(.title2b)
+                .multilineTextAlignment(.center)
+                .lineLimit(1)
             Spacer()
         }
     }
     
-    private var searchContent: some View {
+    private func detailWithChip(count: Int) -> some View {
+        HStack {
+            Spacer()
+            
+            LogoChip(type: .small, count: count)
+                .padding(.trailing, 20)
+        }
+    }
+    
+    private var searchBar: some View {
         HStack(spacing: 12) {
-            LogoChip(type: .small, count: 10)
+            if style.showsBackButton {
+                backButtonView
+            }
             
             HStack(spacing: 8) {
                 Image(.icSearchGray600)
@@ -108,18 +182,13 @@ struct CustomNavigationBar: View {
                 }
             }
             .padding(.horizontal, 12)
-            .frame(height: 44.adjustedH)
-            .background(
+            .background(.white)
+            .overlay(
                 RoundedRectangle(cornerRadius: 10)
-                    .fill(Color.white)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color(.gray200), lineWidth: 1)
-                    )
+                    .strokeBorder(.gray400)
             )
-            .onTapGesture {
-                onSearchSubmit?()
-            }
+            .cornerRadius(10)
+            .frame(height: 44.adjusted)
         }
         .padding(.horizontal, 16)
     }
@@ -172,8 +241,4 @@ struct CustomNavigationBar_Previews: PreviewProvider {
         .padding()
         .previewLayout(.sizeThatFits)
     }
-}
-
-#Preview {
-    Home()
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -92,7 +92,7 @@ struct CustomNavigationBar: View {
                     .fill(Color.white)
                     .overlay(
                         RoundedRectangle(cornerRadius: 10)
-                            .stroke(Color(.gray200), lineWidth: 1)
+                            .strokeBorder(.gray200)
                     )
             )
             .onTapGesture {
@@ -129,7 +129,7 @@ struct CustomNavigationBar: View {
             Spacer()
             Button(action: onBackTapped) {
                 Image(.icCloseGray400)
-                    .foregroundStyle(.gray)
+                    .foregroundStyle(.gray400)
             }
         }
         .padding(.horizontal, 16)
@@ -182,10 +182,10 @@ struct CustomNavigationBar: View {
                 }
             }
             .padding(.horizontal, 12)
-            .background(Color(.white))
+            .background(.white)
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
-                    .stroke(Color(.gray400), lineWidth: 1)
+                    .strokeBorder(.gray400)
             )
             .cornerRadius(10)
             .frame(height: 44.adjusted)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -8,26 +8,26 @@
 import SwiftUI
 
 enum NavigationBarStyle {
-    // 기본 네비게이션
-    case primary
+    //기본네비
+    case navTopPrimaryOneCenter(isLiked: Bool)   
+
     
     // 검색 관련
-    case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
+    case navTopSearchNormalDefault(showBackButton: Bool = true)
     
     // 위치 관련
-    case locationTitle    // 위치 제목만 표시
-    case locationDetail   // 위치 상세 정보 표시
+    case navTopPrimaryOneLeft      // 위치 제목만 표시
+    case navTopPrimaryTwoLeft      // 위치 상세 정보 표시
     
     // 상세 화면 관련
-    case detail(isLiked: Bool)         // 좋아요 기능이 있는 상세
-    case detailWithChip(count: Int)    // 카운트 칩이 있는 상세
+    case navTopPrimaryOneChip(count: Int)        // 카운트 칩이 있는 상세
     
     // 백 버튼 표시 여부
     var showsBackButton: Bool {
         switch self {
-        case .locationDetail, .locationTitle:
+        case .navTopPrimaryTwoLeft, .navTopPrimaryOneLeft:
             return false
-        case .search(let showBackButton):
+        case .navTopSearchNormalDefault(let showBackButton):
             return showBackButton
         default:
             return true

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -8,26 +8,26 @@
 import SwiftUI
 
 enum NavigationBarStyle {
-    //기본네비
-    case navTopPrimaryOneCenter(isLiked: Bool)   
-
     
     // 검색 관련
-    case navTopSearchNormalDefault(showBackButton: Bool = true)
+    case searchContent //지도에서 왼쪽에 칩 있는거
+    case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
+    case searchBar
     
     // 위치 관련
-    case navTopPrimaryOneLeft      // 위치 제목만 표시
-    case navTopPrimaryTwoLeft      // 위치 상세 정보 표시
+    case locationTitle    // 위치 제목 + 오른쪽 X 버튼
+    case locationDetail   // 탐색 리스트 - 현위치 + > + 오른쪽 칩 아이콘
     
     // 상세 화면 관련
-    case navTopPrimaryOneChip(count: Int)        // 카운트 칩이 있는 상세
+    case detail(isLiked: Bool)         // < + 가운데 타이틀 사용 (신고하기)
+    case detailWithChip(count: Int)    // < + 오른쪽 칩 (가운데 타이틀 없음)
     
     // 백 버튼 표시 여부
     var showsBackButton: Bool {
         switch self {
-        case .navTopPrimaryTwoLeft, .navTopPrimaryOneLeft:
+        case .locationDetail, .locationTitle, .searchContent:
             return false
-        case .navTopSearchNormalDefault(let showBackButton):
+        case .search(let showBackButton):
             return showBackButton
         default:
             return true

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/NavigationBarStyle.swift
@@ -19,7 +19,7 @@ enum NavigationBarStyle {
     case locationDetail   // 탐색 리스트 - 현위치 + > + 오른쪽 칩 아이콘
     
     // 상세 화면 관련
-    case detail(isLiked: Bool)         // < + 가운데 타이틀 사용 (신고하기)
+    case detail         // < + 가운데 타이틀 사용 (신고하기)
     case detailWithChip(count: Int)    // < + 오른쪽 칩 (가운데 타이틀 없음)
     
     // 백 버튼 표시 여부

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
@@ -1,235 +1,235 @@
+////
+////  DetailView.swift
+////  SpoonMe
+////
+////  Created by 이지훈 on 1/2/25.
+////
 //
-//  DetailView.swift
-//  SpoonMe
+//import SwiftUI
+//import NMapsMap
 //
-//  Created by 이지훈 on 1/2/25.
+//struct DetailView: View {
+//    
+//    // MARK: - Properties
+//    
+//    private let userImage = Image(.icCafeBlue)
+//    private let userName: String = "럭키 백희"
+//    private let placeAdress: String = "서울시 마포구 수저"
+//    
+//    private var searchName = "연남"
+//    private var appName: String = "Spoony"
+//    
+//    // MARK: - body
+//    
+//    var body: some View {
+//        
+//        CustomNavigationBar(style: .detailWithChip(count: 99)) {
+//            print("하이")
+//        }
+//        
+//        ScrollView(.vertical) {
+//            VStack(spacing: 0) {
+//                userProfileSection
+//                ImageSection
+//                ReviewSection
+//                PlaceInfoSection
+//            }
+//        }
+//        
+//        bottomView
+//    }
+//}
 //
-
-import SwiftUI
-import NMapsMap
-
-struct DetailView: View {
-    
-    // MARK: - Properties
-    
-    private let userImage = Image(.icCafeBlue)
-    private let userName: String = "럭키 백희"
-    private let placeAdress: String = "서울시 마포구 수저"
-    
-    private var searchName = "연남"
-    private var appName: String = "Spoony"
-    
-    // MARK: - body
-    
-    var body: some View {
-        
-        CustomNavigationBar(style: .detailWithChip(count: 99)) {
-            print("하이")
-        }
-        
-        ScrollView(.vertical) {
-            VStack(spacing: 0) {
-                userProfileSection
-                ImageSection
-                ReviewSection
-                PlaceInfoSection
-            }
-        }
-        
-        bottomView
-    }
-}
-
-// MARK: - SubViews
-
-extension DetailView {
-    private var userProfileSection: some View {
-        
-        HStack(spacing: 16.0) {
-            
-            Circle()
-                .fill(Color.pink)
-                .scaledToFit()
-                .frame(width: 48, height: 48)
-            
-            VStack(alignment: .leading, spacing: 4) {
-                Text(userName)
-                    .font(.body2b)
-                    .foregroundStyle(.black)
-                
-                Text(placeAdress)
-                    .font(.caption1b)
-                    .foregroundStyle(.gray400)
-            }
-            
-            Spacer()
-            
-            Image(.icMenu)
-            
-        }.padding(EdgeInsets(top: 11.5, leading: 20, bottom: 11.5, trailing: 20))
-            .padding(.bottom, 24.adjustedH)
-    }
-    
-    private var ImageSection: some View {
-        
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 16) {
-                ForEach(0..<4) { _ in
-                    Image(.imgFood)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 278.adjusted)
-                    //                        .blur(radius: 12)
-                        .cornerRadius(11.16)
-                }
-                .frame(height: 278.adjustedH)
-            }
-            .padding(.leading, 20.adjusted)
-            .padding(.trailing, 20.adjusted)
-            .padding(.bottom, 32.adjustedH)
-        }
-    }
-    
-    private var ReviewSection: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Rectangle()
-                .frame(width: 61.adjusted, height: 24.adjustedH)
-                .cornerRadius(12)
-                .foregroundStyle(.purple400)
-            
-            Text("인생 이자카야. 고등어 초밥 안주가 그냥 미쳤어요.".splitZeroWidthSpace())
-                .font(.title1b)
-                .foregroundStyle(.black)
-            
-            Text("2025년 1월 2일")
-                .font(.caption1m)
-                .foregroundStyle(.gray400)
-            
-            Spacer().frame(height: 16.adjustedH)
-            
-            Text("이자카야인데 친구랑 가서 안주만 5개 넘게 시킴.. 명성이 자자한 고등어봉 초밥은 꼭 시키세요! 입에 넣자마자 사르르 녹아 없어짐. 그리고 밤 후식 진짜 맛도리니까 밤 디저트 좋아하는 사람이면 꼭 먹어보기! ")
-                .font(.body2m)
-                .foregroundStyle(.gray900)
-            
-        }
-        .padding(.horizontal, 20.adjusted)
-        .padding(.bottom, 32.adjustedH)
-    }
-    
-    private var PlaceInfoSection: some View {
-        VStack(spacing: 0) {
-            ZStack(alignment: .bottom) {
-                
-                Rectangle()
-                    .frame(height: 166.adjustedH)
-                    .cornerRadius(20)
-                    .foregroundStyle(.gray0)
-                    .overlay {
-                        menuInfo
-                    }
-                Line()
-                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [8.adjustedH]))
-                    .foregroundStyle(.gray200)
-                    .frame(width: 266.adjusted, height: 1)
-                
-            }
-            ZStack {
-                Rectangle()
-                    .frame(height: 134.adjustedH)
-                    .cornerRadius(20)
-                    .foregroundStyle(.gray0)
-                
-                LocationInfo
-            }
-        }.padding(.horizontal, 20.adjusted)
-    }
-    
-    private var menuInfo: some View {
-        VStack(alignment: .leading, spacing: 12.adjustedH) {
-            Text("Menu")
-                .font(.body1b)
-                .foregroundStyle(.spoonBlack)
-            menuList
-            menuList
-            menuList
-        }.padding(.leading, 16.adjusted)
-        
-    }
-    
-    private var LocationInfo: some View {
-        HStack {
-            VStack(alignment: .leading, spacing: 12.adjustedH) {
-                Text("Location")
-                    .font(.body1b)
-                    .foregroundStyle(.spoonBlack)
-                Text("상호명")
-                    .font(.title2sb)
-                    .foregroundStyle(.spoonBlack)
-                HStack(spacing: 4) {
-                    Image(.icMapGray400)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 20.adjusted, height: 20.adjustedH)
-                    
-                    Text("주소")
-                        .font(.body2m)
-                        .foregroundStyle(.spoonBlack)
-                }
-            }
-            Spacer()
-        }.padding(.leading, 16.adjusted)
-    }
-    
-    private var menuList: some View {
-        HStack(spacing: 4) {
-            Image(.icSpoonGray600)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 20.adjusted, height: 20.adjustedH)
-            Text("메뉴")
-                .font(.body2m)
-            Spacer()
-        }
-    }
-    
-    private var bottomView: some View {
-        HStack(spacing: 0) {
-            SpoonyButton(style: .secondary, size: .medium, title: "길찾기", disabled: .constant(false)) {
-                let url = URL(string: "nmap://search?query=\(searchName)&appname=\(appName)")!
-                let appStoreURL = URL(string: "http://itunes.apple.com/app/id311867728?mt=8")!
-                
-                if UIApplication.shared.canOpenURL(url) {
-                    UIApplication.shared.open(url)
-                } else {
-                    UIApplication.shared.open(appStoreURL)
-                }
-            }
-            
-            Spacer()
-            
-            VStack(spacing: 4) {
-                Image(.icAddmapGray400)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(width: 56.adjusted, height: 32.adjustedH)
-                
-                Text("99")
-                    .font(.caption1m)
-                    .foregroundStyle(.gray800)
-            }
-        }.padding(.horizontal, 20.adjusted)
-    }
-}
-
-#Preview {
-    DetailView()
-}
-
-struct Line: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.move(to: CGPoint(x: 0, y: 0))
-        path.addLine(to: CGPoint(x: rect.width, y: 0))
-        return path
-    }
-}
+//// MARK: - SubViews
+//
+//extension DetailView {
+//    private var userProfileSection: some View {
+//        
+//        HStack(spacing: 16.0) {
+//            
+//            Circle()
+//                .fill(Color.pink)
+//                .scaledToFit()
+//                .frame(width: 48, height: 48)
+//            
+//            VStack(alignment: .leading, spacing: 4) {
+//                Text(userName)
+//                    .font(.body2b)
+//                    .foregroundStyle(.black)
+//                
+//                Text(placeAdress)
+//                    .font(.caption1b)
+//                    .foregroundStyle(.gray400)
+//            }
+//            
+//            Spacer()
+//            
+//            Image(.icMenu)
+//            
+//        }.padding(EdgeInsets(top: 11.5, leading: 20, bottom: 11.5, trailing: 20))
+//            .padding(.bottom, 24.adjustedH)
+//    }
+//    
+//    private var ImageSection: some View {
+//        
+//        ScrollView(.horizontal, showsIndicators: false) {
+//            HStack(spacing: 16) {
+//                ForEach(0..<4) { _ in
+//                    Image(.imgFood)
+//                        .resizable()
+//                        .scaledToFit()
+//                        .frame(width: 278.adjusted)
+//                    //                        .blur(radius: 12)
+//                        .cornerRadius(11.16)
+//                }
+//                .frame(height: 278.adjustedH)
+//            }
+//            .padding(.leading, 20.adjusted)
+//            .padding(.trailing, 20.adjusted)
+//            .padding(.bottom, 32.adjustedH)
+//        }
+//    }
+//    
+//    private var ReviewSection: some View {
+//        VStack(alignment: .leading, spacing: 8) {
+//            Rectangle()
+//                .frame(width: 61.adjusted, height: 24.adjustedH)
+//                .cornerRadius(12)
+//                .foregroundStyle(.purple400)
+//            
+//            Text("인생 이자카야. 고등어 초밥 안주가 그냥 미쳤어요.".splitZeroWidthSpace())
+//                .font(.title1b)
+//                .foregroundStyle(.black)
+//            
+//            Text("2025년 1월 2일")
+//                .font(.caption1m)
+//                .foregroundStyle(.gray400)
+//            
+//            Spacer().frame(height: 16.adjustedH)
+//            
+//            Text("이자카야인데 친구랑 가서 안주만 5개 넘게 시킴.. 명성이 자자한 고등어봉 초밥은 꼭 시키세요! 입에 넣자마자 사르르 녹아 없어짐. 그리고 밤 후식 진짜 맛도리니까 밤 디저트 좋아하는 사람이면 꼭 먹어보기! ")
+//                .font(.body2m)
+//                .foregroundStyle(.gray900)
+//            
+//        }
+//        .padding(.horizontal, 20.adjusted)
+//        .padding(.bottom, 32.adjustedH)
+//    }
+//    
+//    private var PlaceInfoSection: some View {
+//        VStack(spacing: 0) {
+//            ZStack(alignment: .bottom) {
+//                
+//                Rectangle()
+//                    .frame(height: 166.adjustedH)
+//                    .cornerRadius(20)
+//                    .foregroundStyle(.gray0)
+//                    .overlay {
+//                        menuInfo
+//                    }
+//                Line()
+//                    .stroke(style: StrokeStyle(lineWidth: 1, dash: [8.adjustedH]))
+//                    .foregroundStyle(.gray200)
+//                    .frame(width: 266.adjusted, height: 1)
+//                
+//            }
+//            ZStack {
+//                Rectangle()
+//                    .frame(height: 134.adjustedH)
+//                    .cornerRadius(20)
+//                    .foregroundStyle(.gray0)
+//                
+//                LocationInfo
+//            }
+//        }.padding(.horizontal, 20.adjusted)
+//    }
+//    
+//    private var menuInfo: some View {
+//        VStack(alignment: .leading, spacing: 12.adjustedH) {
+//            Text("Menu")
+//                .font(.body1b)
+//                .foregroundStyle(.spoonBlack)
+//            menuList
+//            menuList
+//            menuList
+//        }.padding(.leading, 16.adjusted)
+//        
+//    }
+//    
+//    private var LocationInfo: some View {
+//        HStack {
+//            VStack(alignment: .leading, spacing: 12.adjustedH) {
+//                Text("Location")
+//                    .font(.body1b)
+//                    .foregroundStyle(.spoonBlack)
+//                Text("상호명")
+//                    .font(.title2sb)
+//                    .foregroundStyle(.spoonBlack)
+//                HStack(spacing: 4) {
+//                    Image(.icMapGray400)
+//                        .resizable()
+//                        .scaledToFit()
+//                        .frame(width: 20.adjusted, height: 20.adjustedH)
+//                    
+//                    Text("주소")
+//                        .font(.body2m)
+//                        .foregroundStyle(.spoonBlack)
+//                }
+//            }
+//            Spacer()
+//        }.padding(.leading, 16.adjusted)
+//    }
+//    
+//    private var menuList: some View {
+//        HStack(spacing: 4) {
+//            Image(.icSpoonGray600)
+//                .resizable()
+//                .scaledToFit()
+//                .frame(width: 20.adjusted, height: 20.adjustedH)
+//            Text("메뉴")
+//                .font(.body2m)
+//            Spacer()
+//        }
+//    }
+//    
+//    private var bottomView: some View {
+//        HStack(spacing: 0) {
+//            SpoonyButton(style: .secondary, size: .medium, title: "길찾기", disabled: .constant(false)) {
+//                let url = URL(string: "nmap://search?query=\(searchName)&appname=\(appName)")!
+//                let appStoreURL = URL(string: "http://itunes.apple.com/app/id311867728?mt=8")!
+//                
+//                if UIApplication.shared.canOpenURL(url) {
+//                    UIApplication.shared.open(url)
+//                } else {
+//                    UIApplication.shared.open(appStoreURL)
+//                }
+//            }
+//            
+//            Spacer()
+//            
+//            VStack(spacing: 4) {
+//                Image(.icAddmapGray400)
+//                    .resizable()
+//                    .scaledToFit()
+//                    .frame(width: 56.adjusted, height: 32.adjustedH)
+//                
+//                Text("99")
+//                    .font(.caption1m)
+//                    .foregroundStyle(.gray800)
+//            }
+//        }.padding(.horizontal, 20.adjusted)
+//    }
+//}
+//
+//#Preview {
+//    DetailView()
+//}
+//
+//struct Line: Shape {
+//    func path(in rect: CGRect) -> Path {
+//        var path = Path()
+//        path.move(to: CGPoint(x: 0, y: 0))
+//        path.addLine(to: CGPoint(x: rect.width, y: 0))
+//        return path
+//    }
+//}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
@@ -28,9 +28,9 @@ struct Explore: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            CustomNavigationBar(style: .locationDetail, title: navigationTitle, onLocationTapped: {
-                isPresentedLocation = true
-            })
+//            CustomNavigationBar(style: .locationDetail, title: navigationTitle, onLocationTapped: {
+//                isPresentedLocation = true
+//            })
             
             categoryList
             filterButton

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
@@ -49,7 +49,7 @@ struct Home: View {
                
                VStack(spacing: 0) {
                    CustomNavigationBar(
-                       style: .navTopSearchNormalDefault(showBackButton: false),
+                    style: .detail(isLiked: false), 
                        searchText: $searchText,
                        onBackTapped: {},
                        onSearchSubmit: nil,

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
@@ -49,7 +49,7 @@ struct Home: View {
                
                VStack(spacing: 0) {
                    CustomNavigationBar(
-                       style: .search(showBackButton: false),
+                       style: .navTopSearchNormalDefault(showBackButton: false),
                        searchText: $searchText,
                        onBackTapped: {},
                        onSearchSubmit: nil,

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
@@ -49,7 +49,7 @@ struct Home: View {
                
                VStack(spacing: 0) {
                    CustomNavigationBar(
-                    style: .detail(isLiked: false), 
+                    style: .detail, 
                        searchText: $searchText,
                        onBackTapped: {},
                        onSearchSubmit: nil,


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #66 

## 📄 작업 내용
- 네비게이션 UI를 제대로 수정합니다.

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "
<img width="250" alt="스크린샷 2025-01-16 오후 11 34 43" src="https://github.com/user-attachments/assets/01297d35-297b-4cc0-91ae-038a986d47f1" />" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명
- 네비게이션 스타일
```swift
 
    // 검색 관련
    case searchContent //지도에서 왼쪽에 칩 있는거
    case search(showBackButton: Bool = true) // 뒤로가기 버튼 표시 여부 추가
    case searchBar
    
    // 위치 관련
    case locationTitle    // 위치 제목 + 오른쪽 X 버튼
    case locationDetail   // 탐색 리스트 - 현위치 + > + 오른쪽 칩 아이콘
    
    // 상세 화면 관련
    case detail(isLiked: Bool)         // < + 가운데 타이틀 사용 (신고하기)
    case detailWithChip(count: Int)    // < + 오른쪽 칩 (가운데 타이틀 없음)
    
    // 백 버튼 표시 여부
    var showsBackButton: Bool {
        switch self {
        case .locationDetail, .locationTitle, .searchContent:
            return false
        case .search(let showBackButton):
            return showBackButton
        default:
            return true
        }
    }
```
