### PR TITLE
 Refactor/#99 등록뷰 MVI 변경

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterIntent.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterIntent.swift
@@ -1,0 +1,30 @@
+//
+//  RegisterIntent.swift
+//  Spoony-iOS
+//
+//  Created by 최안용 on 1/20/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+enum RegisterIntent {
+    case updateText(String, RegisterInputText)
+    case updateTextList(String, UUID)
+    case didTapButtonIcon(RegisterInputText)
+    case deleteTextList(TextList)
+    case updateButtonState(Bool, RegisterCurrentViewType)
+    case updateSelectedCategoryChip([CategoryChip])
+    case didTapPlaceInfoCell(PlaceInfo)
+    case didTapPlaceInfoCellIcon    
+    case didTapRecommendPlusButton
+    case didTapNextButton(RegisterCurrentViewType)    
+    case didTapkeyboardEnter
+    case updateToolTipState
+    case didTapBackground(RegisterCurrentViewType)
+    case updateToast(Toast?)
+    case movePreviousView
+    case updateTextError(Bool, RegisterInputText)
+    case updatePickerItems([PhotosPickerItem])
+    case deleteImage(UploadImage)
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterState.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterState.swift
@@ -1,0 +1,47 @@
+//
+//  RegisterState.swift
+//  Spoony-iOS
+//
+//  Created by 최안용 on 1/20/25.
+//
+
+import SwiftUI
+import PhotosUI
+
+struct RegisterState {
+    // MARK: - Register
+    var registerStep: RegisterStep = .start
+    
+    // MARK: - InfoStepView
+    var placeText: String = ""
+    var recommendTexts: [TextList] = [.init()]
+    
+    var toast: Toast?
+    // 나중에 api 연결
+    var categorys: [CategoryChip] = CategoryChip.sample()
+    var selectedCategory: [CategoryChip] = []
+    
+    var isDropDownPresented: Bool = false
+    var isToolTipPresented: Bool = true
+    
+    var isDisableStartButton: Bool = true
+    var isDisablePlusButton: Bool = false
+    
+    // MARK: - ReviewStepView
+    var simpleText: String = ""
+    var detailText: String = ""
+    
+    var selectableCount = 5
+    
+    var selectedPlace: PlaceInfo?
+    // 나중에 api 연결
+    var searchedPlaces: [PlaceInfo] = PlaceInfo.sample()
+    var pickerItems: [PhotosPickerItem] = []
+    var uploadImages: [UploadImage] = []
+    
+    var isDisableMiddleButton: Bool = true
+    var isSimpleTextError: Bool = true
+    var isDetailTextError: Bool = true
+    
+    var uploadImageErrorState: UploadImageErrorState = .initial
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct InfoStepView: View {
     @ObservedObject private var store: RegisterStore
-    @State private var isDropDown: Bool = false
     
     init(store: RegisterStore) {
         self.store = store
@@ -25,10 +24,14 @@ struct InfoStepView: View {
         }
         .background(.white)
         .onTapGesture {
-            isDropDown = false
+            store.dispatch(.didTapBackground(.start))
             hideKeyboard()
         }
-        .toastView(toast: $store.toast)
+        .toastView(toast: Binding(get: {
+            store.state.toast
+        }, set: { newValue in
+            store.dispatch(.updateToast(newValue))
+        }))
     }
 }
 
@@ -42,7 +45,7 @@ extension InfoStepView {
             recommendSection
         }
         .overlay(alignment: .top) {
-            if isDropDown {
+            if store.state.isDropDownPresented {
                 dropDownView
                     .padding(.top, 81)
             }
@@ -65,29 +68,27 @@ extension InfoStepView {
                 .font(.body1sb)
                 .foregroundStyle(.spoonBlack)
             
-            if !store.isSelected {
+            if store.state.selectedPlace == nil {
                 SpoonyTextField(
                     text: Binding(
-                        get: { store.text },
+                        get: { store.state.placeText },
                         set: { newValue in
-                            store.text = newValue
+                            store.dispatch(.updateText(newValue, .place))
                         }
                     ),
                     style: .icon,
                     placeholder: "어떤 장소를 한 입 줄까요?",
                     isError: .constant(false)
                 ) {
-                    store.text = ""
-                    isDropDown = false
+                    store.dispatch(.didTapButtonIcon(.place))
                 }
                 .onSubmit {
-                    isDropDown = true
+                    store.dispatch(.didTapkeyboardEnter)
                 }
             } else {
-                if let place = store.selectedPlace {
+                if let place = store.state.selectedPlace {
                     PlaceInfoCell(placeInfo: place, placeInfoType: .selectedCell) {
-                        store.selectedPlace = nil
-                        store.isSelected = false
+                        store.dispatch(.didTapPlaceInfoCellIcon)
                     }
                 }
             }
@@ -101,7 +102,14 @@ extension InfoStepView {
                 .font(.body1sb)
                 .foregroundStyle(.spoonBlack)
             
-            ChipsContainerView(selectedItem: $store.selectedCategory, items: store.categorys)
+            ChipsContainerView(
+                selectedItem: Binding(get: {
+                    store.state.selectedCategory
+                }, set: { newValue in
+                    store.dispatch(.updateSelectedCategoryChip(newValue))
+                }),
+                items: store.state.categorys
+            )
         }
         .padding(.bottom, 40)
     }
@@ -114,18 +122,21 @@ extension InfoStepView {
                 .padding(.bottom, 12)
             
             VStack(spacing: 8) {
-                ForEach(Array(store.recommendMenu.enumerated()), id: \.offset) { index, _ in
+                ForEach(store.state.recommendTexts, id: \.id) { text in
                     SpoonyTextField(
-                        text: $store.recommendMenu[index],
-                        style: .normal(isIcon: store.recommendMenu.count > 1),
+                        text: Binding(get: {
+                            text.text
+                        }, set: { newValue in
+                            store.dispatch(.updateTextList(newValue, text.id))
+                        }),
+                        style: .normal(isIcon: store.state.recommendTexts.count > 1),
                         placeholder: "메뉴 이름",
                         isError: .constant(false)
                     ) {
-                        guard index < store.recommendMenu.count else { return }
-                        store.recommendMenu.remove(at: index)
+                        store.dispatch(.deleteTextList(text))
                     }
                 }
-                if store.recommendMenu.count < 3 {
+                if store.state.recommendTexts.count < 3 {
                     plusButton
                 }
             }
@@ -134,14 +145,10 @@ extension InfoStepView {
     
     private var dropDownView: some View {
         VStack(spacing: 0) {
-            ForEach(store.searchPlaces, id: \.id) { place in
+            ForEach(store.state.searchedPlaces, id: \.id) { place in
                 PlaceInfoCell(placeInfo: place, placeInfoType: .listCell)
                     .onTapGesture {
-                        store.selectedPlace = place
-                        store.isSelected = true
-                        isDropDown = false
-                        store.text = ""
-                        store.toast = .init(style: .gray, message: "앗! 이미 등록한 맛집이에요", yOffset: 556.adjustedH)
+                        store.dispatch(.didTapPlaceInfoCell(place))
                     }
                     .overlay(alignment: .bottom) {
                         Rectangle()
@@ -163,7 +170,7 @@ extension InfoStepView {
     
     private var plusButton: some View {
         return Button {
-            store.plusButtonTapped()
+            store.dispatch(.didTapRecommendPlusButton)
         } label: {
             Image(.icPlusGray400)
                 .resizable()
@@ -176,7 +183,7 @@ extension InfoStepView {
                 }
         }
         .buttonStyle(.plain)
-        .disabled(store.plusButtonDisabled)
+        .disabled(store.state.isDisablePlusButton)
     }
     
     private var nextButton: some View {
@@ -184,20 +191,26 @@ extension InfoStepView {
             style: .primary,
             size: .xlarge,
             title: "다음",
-            disabled: $store.disableFirstButton
+            disabled: Binding(
+                get: {
+                    store.state.isDisableStartButton
+                }, set: { newValue in
+                    store.dispatch(.updateButtonState(newValue, .start))
+                }
+            )
         ) {
-            store.step = .middle
+            store.dispatch(.didTapNextButton(.start))
         }
         .padding(.bottom, 20)
         .padding(.top, 61)
         .overlay(alignment: .top) {
             ToolTipView()
                 .padding(.top, 5)
-                .opacity(store.isToolTipPresented ? 1 : 0)
+                .opacity(store.state.isToolTipPresented ? 1 : 0)
                 .task {
                     do {
                         try await Task.sleep(for: .seconds(3))
-                        store.isToolTipPresented = false
+                        store.dispatch(.updateToolTipState)
                     } catch {
                         
                     }
@@ -208,5 +221,5 @@ extension InfoStepView {
 }
 
 #Preview {
-    InfoStepView(store: .init())
+    InfoStepView(store: .init(navigationManager: .init()))
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
@@ -67,7 +67,12 @@ extension InfoStepView {
             
             if !store.isSelected {
                 SpoonyTextField(
-                    text: $store.text,
+                    text: Binding(
+                        get: { store.text },
+                        set: { newValue in
+                            store.text = newValue
+                        }
+                    ),
                     style: .icon,
                     placeholder: "어떤 장소를 한 입 줄까요?",
                     isError: .constant(false)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/Register.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/Register.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct Register: View {
-    @StateObject private var store: RegisterStore = RegisterStore()
+    @StateObject var store: RegisterStore
     
     var body: some View {
         VStack(spacing: 0) {
@@ -16,7 +16,7 @@ struct Register: View {
             
             ScrollView {
                 Group {
-                    switch store.step {
+                    switch store.state.registerStep {
                     case .start:
                         InfoStepView(store: store)
                     case .middle, .end:
@@ -24,7 +24,7 @@ struct Register: View {
                     }
                 }
                 .transition(.slide)
-                .animation(.easeInOut, value: store.step)
+                .animation(.easeInOut, value: store.state.registerStep)
             }
         }
     }
@@ -34,9 +34,9 @@ extension Register {
     private var customNavigationBar: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                if store.step != .start {
+                if store.state.registerStep != .start {
                     Button {
-                        store.step = .start
+                        store.dispatch(.movePreviousView)
                     } label: {
                         Image(.icArrowLeftGray700)
                             .resizable()
@@ -53,12 +53,12 @@ extension Register {
     }
     
     private var progressBar: some View {
-        ProgressView(value: 1.0/3 * Double(store.step.rawValue))
+        ProgressView(value: 1.0/3 * Double(store.state.registerStep.rawValue))
             .frame(height: 4.adjustedH)
             .progressViewStyle(.linear)
             .tint(.main400)
             .padding(.horizontal, 20)
-            .animation(.easeInOut, value: store.step)
+            .animation(.easeInOut, value: store.state.registerStep)
     }
 }
 
@@ -69,5 +69,5 @@ enum RegisterStep: Int {
 }
 
 #Preview {
-    Register()
+    Register(store: .init(navigationManager: .init()))
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/SpoonyTabView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/SpoonyTabView.swift
@@ -39,11 +39,13 @@ struct SpoonyTabView: View {
                         }
                     case .register:
                         NavigationStack(path: $navigationManager.registerPath) {
-                            Register()
-                                .navigationDestination(for: ViewType.self) { view in
-                                    navigationManager.build(view)
-                                        .navigationBarBackButtonHidden()
-                                }
+                            Register(
+                                store: .init(navigationManager: navigationManager)
+                            )
+                            .navigationDestination(for: ViewType.self) { view in
+                                navigationManager.build(view)
+                                    .navigationBarBackButtonHidden()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #99 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- MVI 리펙토링

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`InfoStepView`
- 이전 코드는 삭제 부분만 ForEach문을 통해 Index로 접근하여 사용하였는데 get, get을 통한 바인딩을 하니까 
ForEach 내부에서 text를 변경하게 되어 인덱스 오류가 발생하였습니다. 그래서 배열 Text를 다루기 위한 구조체를 
선언하고 UUID 값을 할당하여 해당 id를 통해 갱신 및 삭제가 이루어지도록 구현했습니다.

```
Array(store.state.recommendTexts.enumerated())를 사용하면 인덱스가 offset으로 전달됩니다. 
그러나 배열을 수정할 때(예: 요소를 변경하거나 삭제) ForEach가 요소를 다시 갱신하면서 배열의 크기나 순서가 변경될 수 있습니다. 
이때, 배열이 수정되면 index 값이 더 이상 유효하지 않게 되어 인덱스 오류가 발생할 수 있습니다.
```
```swift
 private var recommendSection: some View {
        VStack(alignment: .leading, spacing: 0) {
            Text("추천 메뉴를 알려주세요")
                .font(.body1sb)
                .foregroundStyle(.spoonBlack)
                .padding(.bottom, 12)
            
            VStack(spacing: 8) {
                ForEach(store.state.recommendTexts, id: \.id) { text in
                    SpoonyTextField(
                        text: Binding(get: {
                            text.text
                        }, set: { newValue in
                            store.dispatch(.updateTextList(newValue, text.id))
                        }),
                        style: .normal(isIcon: store.state.recommendTexts.count > 1),
                        placeholder: "메뉴 이름",
                        isError: .constant(false)
                    ) {
                        store.dispatch(.deleteTextList(text))
                    }
                }
                if store.state.recommendTexts.count < 3 {
                    plusButton
                }
            }
        }
    }
```


## 👀 기타 더 이야기해볼 점
코드가 더 복잡해진 것 같아서 api 붙이고 다시 정리하겠습니다.
