### PR TITLE
[FIx] #128 - 모든 Font CustomModifer로 수정 했습니다.

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
@@ -15,7 +15,7 @@ struct BottomSheetListItem: View {
             VStack(alignment: .leading, spacing: 4) {
                 HStack(spacing: 8) {
                     Text(pickCard.placeName)
-                        .font(.body1b)
+                        .customFont(.body1b)
                         .lineLimit(1)
                         .truncationMode(.tail)
                     
@@ -36,7 +36,7 @@ struct BottomSheetListItem: View {
                         }
                         
                         Text(pickCard.categoryColorResponse.categoryName)
-                            .font(.caption1m)
+                            .customFont(.caption1m)
                             .lineLimit(1)
                     }
                     .padding(.horizontal, 8)
@@ -47,13 +47,13 @@ struct BottomSheetListItem: View {
                 }
                 
                 Text(pickCard.placeAddress)
-                    .font(.caption1m)
+                    .customFont(.caption1m)
                     .foregroundColor(.gray)
                     .lineLimit(1)
                     .truncationMode(.tail)
                 
                 Text(pickCard.postTitle)
-                    .font(.caption1m)
+                    .customFont(.caption1m)
                     .foregroundColor(.gray)
                     .lineLimit(1)
                     .truncationMode(.tail)
@@ -74,7 +74,7 @@ struct BottomSheetListItem: View {
                     image
                         .resizable()
                         .scaledToFill()
-                case .failure(_):
+                case .failure:
                     defaultPlaceholder
                 case .empty:
                     defaultPlaceholder
@@ -136,7 +136,7 @@ struct BottomSheetListView: View {
                         .padding(.top, 10)
                     
                     Text("타이틀")
-                        .font(.system(size: 18, weight: .semibold))
+                        .customFont(.body2b)
                         .padding(.bottom, 8)
                 }
                 .frame(height: 60.adjustedH)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/BottomSheetList.swift
@@ -239,8 +239,3 @@ struct BottomSheetListView: View {
         }
     }
 }
-
-#Preview {
-    Home()
-        .environmentObject(NavigationManager())
-}

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/CustomBottomSheet.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/CustomBottomSheet.swift
@@ -91,8 +91,3 @@ struct CustomBottomSheet<Content: View>: View {
         .ignoresSafeArea()
     }
 }
-
-#Preview {
-    Home()
-        .environmentObject(NavigationManager())
-}

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/CustomBottomSheet.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/CustomBottomSheet.swift
@@ -55,7 +55,7 @@ struct CustomBottomSheet<Content: View>: View {
                             .padding(.top, 10)
                         
                         Text("타이틀")
-                            .font(.body2b)
+                            .customFont(.body2b)
                             .padding(.bottom, 8)
                     }
                     .frame(height: headerHeight)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/FixedBottomSheetView.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/FixedBottomSheetView.swift
@@ -38,7 +38,7 @@ struct FixedBottomSheetView: View {
                         .padding(.leading, 10)
                     
                     Text("아직 추가된 장소가 없어요.\n다른 사람의 리스트를 떠먹어 보세요!")
-                        .font(.body2m)
+                        .customFont(.body2m)
                         .foregroundStyle(.gray500)
                         .multilineTextAlignment(.center)
                     

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/DropDownMenu.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/DropDownMenu.swift
@@ -32,7 +32,7 @@ public struct DropDownMenu: View {
                     }) {
                         HStack {
                             Text(item)
-                                .font(.caption1b)
+                                .customFont(.caption1b)
                                 .foregroundColor(.gray900)
                                 .padding(.vertical, 16.adjustedH)
                                 .padding(.leading, 14.adjustedH)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/IconChip.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/IconChip.swift
@@ -117,7 +117,7 @@ struct IconChip: View {
                 .resizable()
                 .frame(width: 16.adjusted, height: 16.adjustedH)
             Text(title)
-                .font(chipType == .large ? .body2sb : .caption1m)
+                .customFont(chipType == .large ? .body2sb : .caption1m)
                 .foregroundStyle(color.textColor)
         }
         .padding(.vertical, chipType == .large ? 6 : 4)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/LogoChip.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/LogoChip.swift
@@ -19,7 +19,7 @@ struct LogoChip: View {
     var body: some View {
         HStack(spacing: type == .large ? 6 : 5) {
             Text("\(count)")
-                .font(type == .large ? .body1sb : .body2sb)
+                .customFont(type == .large ? .body1sb : .body2sb)
                 .foregroundStyle(.white)
             Image(type == .large ? .imageSpoonLarge : .imageSpoonSmall)
                 .resizable()

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/Navigation/CustomNavigationBar.swift
@@ -84,7 +84,7 @@ struct CustomNavigationBar: View {
                 Text("오늘은 어디서 먹어볼까요?")
                     .foregroundStyle(.gray500)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .font(.body2m)
+                    .customFont(.body2m)
 
             }
             .padding(.horizontal, 12)
@@ -109,7 +109,7 @@ struct CustomNavigationBar: View {
             Button(action: { tappedAction?() }) {
                 HStack {
                     Text(title ?? "홍대입구역")
-                        .font(.title2sb)
+                        .customFont(.title2sb)
                         .foregroundStyle(.spoonBlack)
                     Image(.icArrowRightGray700)
                 }
@@ -127,7 +127,7 @@ struct CustomNavigationBar: View {
         HStack {
             let title = title ?? ""
             Text(title.isEmpty ? "홍대입구역" : title)
-                .font(.title2b)
+                .customFont(.title2b)
                 .foregroundStyle(.spoonBlack)
             Spacer()
             Image(.icCloseGray400)
@@ -145,7 +145,7 @@ struct CustomNavigationBar: View {
         HStack {
             Spacer()
             Text(title ?? "홍대")
-                .font(.title2b)
+                .customFont(.title2b)
                 .multilineTextAlignment(.center)
                 .lineLimit(1)
             Spacer()

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyButton.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyButton.swift
@@ -67,7 +67,7 @@ public struct SpoonyButton: View {
                     }
                 }
                 Text(title)
-                    .font(size.font)
+                    .customFont(size.font)
                     .foregroundStyle(style.foregroundColor)
             }
             .frame(width: size.width, height: size.height)

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextEditor.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextEditor.swift
@@ -66,10 +66,10 @@ extension SpoonyTextEditor {
                 .autocapitalization(.none)
                 .autocorrectionDisabled()
                 .focused($isFocused)
-                .font(.body2m)                
+                .customFont(.body2m)
                 .overlay(alignment: .topLeading) {
                     Text("\(placeholder)")
-                        .font(.body2m)
+                        .customFont(.body2m)
                         .foregroundStyle(text.isEmpty ? .gray500 : .clear)
                         .offset(x: 5.adjusted, y: 8.adjustedH)
                 }
@@ -99,7 +99,7 @@ extension SpoonyTextEditor {
                 }
 
             Text("\(text.count) / \(style.maximumInput)")
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundStyle(errorState != .noError && errorState != .initial ? .error400 : .gray500)
                 .padding(.trailing, 5)
                 .padding(.bottom, 7)
@@ -121,7 +121,7 @@ extension SpoonyTextEditor {
                 .frame(width: 16.adjusted, height: 16.adjusted)
             
             Text("\(message)")
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundStyle(.error400)
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
@@ -74,13 +74,13 @@ extension SpoonyTextField {
             
             TextField(text: $text) {
                 Text(placeholder)
-                    .font(.body2m)
+                    .customFont(.body2m)
                     .foregroundStyle(.gray500)
             }
             .autocapitalization(.none) 
             .autocorrectionDisabled()
             .focused($isFocused)
-            .font(.body2m)
+            .customFont(.body2m)
             .foregroundStyle(.gray900)
             .onChange(of: text) { oldValue, newValue in
                 if style != .icon {
@@ -143,7 +143,7 @@ extension SpoonyTextField {
                     }
                 case .helper:
                     Text("\(text.count) / 30")
-                        .font(.caption1m)
+                        .customFont(.caption1m)
                         .foregroundStyle(errorState != .noError && errorState != .initial ? .error400 : .gray500)
                 }
             }
@@ -164,7 +164,7 @@ extension SpoonyTextField {
                 .frame(width: 16.adjusted, height: 16.adjustedH)
             
             Text("\(message)")
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundStyle(.error400)
         }
         .padding(.top, 8)

--- a/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Extension/View+.swift
@@ -37,4 +37,8 @@ extension View {
     func hideKeyboard() {
         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
     }
+    
+    func customFont(_ font: Font) -> some View {
+        self.modifier(CustomFontModifier(font: font))
+    }
 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/CustomFontModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/CustomFontModifier.swift
@@ -1,0 +1,22 @@
+//
+//  CustomFontModifier.swift
+//  Spoony-iOS
+//
+//  Created by 이명진 on 1/22/25.
+//
+
+import SwiftUI
+
+public struct CustomFontModifier: ViewModifier {
+    let font: Font
+    let lineSpacing: CGFloat = 1.45
+    let letterSpacing: CGFloat = -0.02
+    
+    /// 행 자간을 설정해주는 modifier 입니다.
+    public func body(content: Content) -> some View {
+        content
+            .font(font)
+            .lineSpacing(lineSpacing)
+            .tracking(letterSpacing)
+    }
+}

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/PopupModifier.swift
@@ -55,7 +55,7 @@ struct PopupView: View {
             
             Text(description)
                 .multilineTextAlignment(.center)
-                .font(.body1b)
+                .customFont(.body1b)
                 .padding(.bottom, descriptionYOffset)
             
             HStack(spacing: 12) {

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/ToastModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/ToastModifier.swift
@@ -38,7 +38,7 @@ struct ToastView: View {
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             Text(message)
-                .font(.body2b)
+                .customFont(.body2b)
                 .foregroundStyle(.white)
         }
         .frame(height: 40.adjustedH)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
@@ -111,11 +111,11 @@ extension DetailView {
             
             VStack(alignment: .leading, spacing: 4.adjustedH) {
                 Text(userName)
-                    .font(.body2b)
+                    .customFont(.body2b)
                     .foregroundStyle(.black)
                 
                 Text(placeAdress)
-                    .font(.caption1b)
+                    .customFont(.caption1b)
                     .foregroundStyle(.gray400)
             }
             
@@ -160,11 +160,11 @@ extension DetailView {
             )
             
             Text("인생 이자카야. 고등어 초밥 안주가 그냥 미쳤어요.".splitZeroWidthSpace())
-                .font(.title1b)
+                .customFont(.title1b)
                 .foregroundStyle(.black)
             
             Text("2025년 8월 21일")
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundStyle(.gray400)
             
             Spacer()
@@ -215,7 +215,7 @@ extension DetailView {
     private var menuInfo: some View {
         VStack(alignment: .leading, spacing: 12.adjustedH) {
             Text("Menu")
-                .font(.body1b)
+                .customFont(.body1b)
                 .foregroundStyle(.spoonBlack)
             menuList()
         }
@@ -226,10 +226,10 @@ extension DetailView {
         HStack {
             VStack(alignment: .leading, spacing: 12.adjustedH) {
                 Text("Location")
-                    .font(.body1b)
+                    .customFont(.body1b)
                     .foregroundStyle(.spoonBlack)
                 Text("상호명")
-                    .font(.title2sb)
+                    .customFont(.title2sb)
                     .foregroundStyle(.spoonBlack)
                 HStack(spacing: 4.adjusted) {
                     Image(.icMapGray400)
@@ -238,7 +238,7 @@ extension DetailView {
                         .frame(width: 20.adjusted, height: 20.adjustedH)
                     
                     Text("서울 마포구 연희로11가길 39")
-                        .font(.body2m)
+                        .customFont(.body2m)
                         .foregroundStyle(.spoonBlack)
                 }
             }
@@ -324,7 +324,7 @@ struct menuList: View {
                         .scaledToFit()
                         .frame(width: 20.adjusted, height: 20.adjustedH)
                     Text(menus[index])
-                        .font(.body2m)
+                        .customFont(.body2m)
                         .lineLimit(2)
                     Spacer()
                 }
@@ -362,7 +362,7 @@ struct SpoonButton: View {
                 .padding(EdgeInsets(top: 1.5, leading: 12, bottom: 4, trailing: 12))
             
             Text("\(scrapCount)")
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundStyle(isScrap ? .main400 : .gray800)
                 .padding(.bottom, 1.5)
         }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
@@ -87,7 +87,7 @@ extension Explore {
         HStack(spacing: 2) {
             Spacer()
             Text(store.selectedFilter.title)
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundStyle(.gray700)
             Image(.icFilterGray700)
                 .resizable()
@@ -108,7 +108,7 @@ extension Explore {
             
             Text("아직 발견된 장소가 없어요.\n나만의 리스트를 공유해 볼까요?")
                 .multilineTextAlignment(.center)
-                .font(.body2m)
+                .customFont(.body2m)
                 .foregroundStyle(.gray500)
                 .padding(.top, 30)
             

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/ExploreCell.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/ExploreCell.swift
@@ -33,21 +33,21 @@ struct ExploreCell: View {
                     .frame(width: 16.adjusted, height: 16.adjustedH)
                     .padding(.trailing, 4)
                 Text("\(feed.zzimCount)")
-                    .font(.caption2b)
+                    .customFont(.caption2b)
                     .foregroundStyle(.gray500)
             }
             
             HStack(alignment: .bottom, spacing: 4) {
                 Text(feed.userName)
-                    .font(.body2b)
+                    .customFont(.body2b)
                     .padding(.leading, 5)
                 Text("\(feed.userRegion) 수저")
-                    .font(.caption2m)
+                    .customFont(.caption2m)
                     .foregroundStyle(.gray500)
             }
             
             Text(feed.title)
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(8)
                 .background(.white, in: RoundedRectangle(cornerRadius: 8))

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/LocationPickerBottomSheet.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/LocationPickerBottomSheet.swift
@@ -59,7 +59,7 @@ struct LocationPickerBottomSheet: View {
             HStack(spacing: 114.adjusted) {
                 Spacer()
                 Text("지역 선택")
-                    .font(.body1b)
+                    .customFont(.body1b)
                 Image(.icCloseGray400)
                     .onTapGesture {
                         isPresented = false
@@ -73,7 +73,7 @@ struct LocationPickerBottomSheet: View {
                 VStack(spacing: 0) {
                     ForEach(RegionType.allCases, id: \.self) { region in
                         Text(region.rawValue)
-                            .font(.body2m)
+                            .customFont(.body2m)
                             .foregroundStyle(
                                 region.rawValue == "서울" ? .spoonBlack : .gray400
                             )
@@ -93,7 +93,7 @@ struct LocationPickerBottomSheet: View {
                         ForEach(SeoulType.allCases, id: \.self) { type in
                             
                             Text(type.rawValue)
-                                .font(.body2m)
+                                .customFont(.body2m)
                                 .foregroundStyle(
                                     tempRegion.rawValue != type.rawValue ? .gray400 : .spoonBlack
                                 )

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Components/PlaceHolderCardView/PlaceCard.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Components/PlaceHolderCardView/PlaceCard.swift
@@ -24,14 +24,14 @@ struct PlaceCard: View {
                 HStack(spacing: 6) {
                     
                     Text(placeName)
-                        .font(.body1b)
+                        .customFont(.body1b)
                     
                     // TODO: 칩으로 대체
                     HStack(spacing: 4) {
                         Image(systemName: "mug.fill")
-                            .font(.system(size: 12))
+                            
                         Text("카페")
-                            .font(.system(size: 14.5))
+                            .customFont(.system(size: 14.5))
                     }
                     .foregroundColor(.pink400)
                     .padding(.horizontal, 12)
@@ -43,7 +43,7 @@ struct PlaceCard: View {
                     HStack(spacing: 4) {
                         Image(.icAddmapGray400)
                         Text(visitorCount)
-                            .font(.caption2b)
+                            .customFont(.caption2b)
                     }
                 }
             }
@@ -52,14 +52,14 @@ struct PlaceCard: View {
             VStack(alignment: .leading, spacing: 6) {
                 HStack {
                     Text(title)
-                        .font(.body2b)
+                        .customFont(.body2b)
                     Text(subTitle)
-                        .font(.caption1m)
+                        .customFont(.caption1m)
                         .foregroundColor(.gray600)
                     
                 }
                 Text(description)
-                    .font(.caption1m)
+                    .customFont(.caption1m)
                     .foregroundColor(.spoonBlack)
             }
             .padding(15)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Components/PlaceHolderCardView/PlaceCardsContainer.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Components/PlaceHolderCardView/PlaceCardsContainer.swift
@@ -35,7 +35,3 @@ struct PlaceCardsContainer: View {
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
     }
 }
-
-#Preview {
- Home()
-}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
@@ -15,8 +15,11 @@ struct Home: View {
     @State private var selectedPlace: CardPlace?
     @State private var currentPage = 0
     @State private var spoonCount: Int = 0
-    private let restaurantService: RestaurantServiceType = RestaurantService()
+    private let restaurantService: HomeServiceType
     
+    init(restaurantService: HomeServiceType = DefaultHomeService()) {
+        self.restaurantService = restaurantService
+    }
     
     var body: some View {
         ZStack(alignment: .bottom) {
@@ -81,10 +84,7 @@ struct Home: View {
                 } catch {
                     print("Failed to fetch spoon count:", error)
                 }
-            }        }
+            }
+        }
     }
-}
-#Preview {
-    Home()
-        .environmentObject(NavigationManager())
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Components/CategoryChipsView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Components/CategoryChipsView.swift
@@ -36,7 +36,7 @@ struct CategoryChipsView: View {
             .frame(width: 16.adjusted, height: 16.adjustedH)
             
             Text(category.title)
-                .font(.body2sb)
+                .customFont(.body2sb)
                 .foregroundStyle(isSelected ? .white : .gray600)
         }
         .padding(.horizontal, 14)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Components/PlaceInfoCell.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Components/PlaceInfoCell.swift
@@ -31,11 +31,11 @@ struct PlaceInfoCell: View {
                     .padding(.trailing, placeInfoType.leadingIconSpacing)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(placeInfo.placeName)
-                        .font(.body2b)
+                        .customFont(.body2b)
                         .foregroundStyle(.spoonBlack)
                     
                     Text(placeInfo.placeRoadAddress)
-                        .font(.caption1m)
+                        .customFont(.caption1m)
                         .foregroundStyle(.gray500)
                 }
                 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
@@ -58,7 +58,7 @@ extension InfoStepView {
     
     private var titleView: some View {
         Text("나의 찐맛집을 등록해볼까요?")
-            .font(.title2b)
+            .customFont(.title2b)
             .foregroundStyle(.spoonBlack)
             .padding(.vertical, 32)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -68,7 +68,7 @@ extension InfoStepView {
     private var placeSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("장소명을 알려주세요")
-                .font(.body1sb)
+                .customFont(.body1sb)
                 .foregroundStyle(.spoonBlack)
             
             if store.state.selectedPlace == nil {
@@ -103,7 +103,7 @@ extension InfoStepView {
         VStack(alignment: .leading, spacing: 12) {
             HStack {
                 Text("카테고리를 골라주세요")
-                    .font(.body1sb)
+                    .customFont(.body1sb)
                     .foregroundStyle(.spoonBlack)
                 Spacer()
             }
@@ -127,7 +127,7 @@ extension InfoStepView {
     private var recommendSection: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("추천 메뉴를 알려주세요")
-                .font(.body1sb)
+                .customFont(.body1sb)
                 .foregroundStyle(.spoonBlack)
                 .padding(.bottom, 12)
             

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ReviewStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ReviewStepView.swift
@@ -55,7 +55,7 @@ struct ReviewStepView: View {
 extension ReviewStepView {
     private var titleView: some View {
         Text("거의 다 왔어요!")
-            .font(.title2b)
+            .customFont(.title2b)
             .foregroundStyle(.spoonBlack)
             .padding(.vertical, 32)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -65,7 +65,7 @@ extension ReviewStepView {
     private var simpleReviewSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("당신의 맛집을 한 줄로 표현해 주세요")
-                .font(.body1sb)
+                .customFont(.body1sb)
                 .foregroundStyle(.spoonBlack)
             
             SpoonyTextField(
@@ -95,7 +95,7 @@ extension ReviewStepView {
         VStack(alignment: .leading, spacing: 12) {
             HStack(spacing: 6) {
                 Text("자세한 후기를 적어주세요")
-                    .font(.body1sb)
+                    .customFont(.body1sb)
                     .foregroundStyle(.spoonBlack)
                 
                 HStack(spacing: 4) {
@@ -104,7 +104,7 @@ extension ReviewStepView {
                         .frame(width: 6.adjusted, height: 6.adjustedH)
                     
                     Text("50자 이상")
-                        .font(.caption1m)
+                        .customFont(.caption1m)
                         .foregroundStyle(.main400)
                 }
             }
@@ -135,7 +135,7 @@ extension ReviewStepView {
     private var pictureUploadSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("음식 사진을 올려주세요")
-                .font(.body1sb)
+                .customFont(.body1sb)
                 .foregroundStyle(.spoonBlack)
                 .padding(.horizontal, 20)
             
@@ -158,7 +158,7 @@ extension ReviewStepView {
                         .resizable()
                         .frame(width: 16.adjusted, height: 16.adjustedH)
                     Text("사진 업로드는 필수예요")
-                        .font(.caption1m)
+                        .customFont(.caption1m)
                         .foregroundStyle(.error400)
                 }
                 .padding(.horizontal, 20)
@@ -185,7 +185,7 @@ extension ReviewStepView {
                     .resizable()
                     .frame(width: 16.adjusted, height: 16.adjustedH)
                 Text("\(store.state.uploadImages.count)/5")
-                    .font(.caption1m)
+                    .customFont(.caption1m)
                     .foregroundStyle(.gray400)
             }
             .frame(width: 80.adjusted, height: 80.adjustedH)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ToolTipView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ToolTipView.swift
@@ -17,7 +17,7 @@ struct ToolTipView: View {
                     .frame(width: 20.adjusted, height: 20.adjusted)
                 
                 Text("장소를 등록하면 수저를 획득할 수 있어요")
-                    .font(.body2b)
+                    .customFont(.body2b)
                     .foregroundStyle(.white)
             }
             .padding(.horizontal, 16)

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Report/Report.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Report/Report.swift
@@ -106,7 +106,7 @@ extension Report {
     private var reportTitle: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("후기를 신고하는 이유가 무엇인가요?")
-                .font(.body1sb)
+                .customFont(.body1sb)
                 .foregroundStyle(.spoonBlack)
                 .padding(.bottom, 12)
             
@@ -128,7 +128,7 @@ extension Report {
     private var reportDescription: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text("자세한 내용을 적어주세요")
-                .font(.body1sb)
+                .customFont(.body1sb)
                 .foregroundStyle(.spoonBlack)
                 .padding(.bottom, 12.adjustedH)
             
@@ -143,7 +143,7 @@ extension Report {
                 Image(.icErrorGray300)
                 
                 Text("스푸니는 철저한 광고 제한 정책과 모니터링을 실시하고 있어요. 부적절한 후기 작성자를 발견하면, '수저 뺏기'로 그들의 수저를 빼앗아 주세요!")
-                    .font(.caption1m)
+                    .customFont(.caption1m)
                     .foregroundStyle(.gray400)
             }
             .padding(10)
@@ -160,7 +160,7 @@ extension Report {
             Image(isSelected ? .icRadioOnGray900 : .icRadioOffGray400)
             
             Text(report.title)
-                .font(.body1m)
+                .customFont(.body1m)
                 .foregroundStyle(.gray900)
             
             Spacer()

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Search/SearchView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Search/SearchView.swift
@@ -78,7 +78,7 @@ struct SearchView: View {
                     .padding(.bottom, 12)
                 
                 Text("구체적인 장소를 검색해 보세요")
-                    .font(.body2m)
+                    .customFont(.body2m)
                     .foregroundColor(.gray600)
             }
             
@@ -90,14 +90,14 @@ struct SearchView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack {
                 Text("최근 검색")
-                    .font(.body2b)
+                    .customFont(.body2b)
                 Spacer()
                 Button("전체삭제") {
                     recentSearches.removeAll()
                     saveRecentSearches()
                     searchState = .empty
                 }
-                .font(.caption1m)
+                .customFont(.caption1m)
                 .foregroundColor(.gray600)
             }
             .padding(.horizontal, 16)
@@ -107,7 +107,7 @@ struct SearchView: View {
                 ForEach(recentSearches, id: \.self) { search in
                     HStack {
                         Text(search)
-                            .font(.body1b)
+                            .customFont(.body1b)
                         Spacer()
                         Button(action: {
                             if let index = recentSearches.firstIndex(of: search) {
@@ -170,12 +170,12 @@ struct SearchView: View {
                     .frame(width: 220.adjusted, height: 100.adjustedH)
                 
                 Text("검색 결과가 없습니다")
-                    .font(.body2sb)
+                    .customFont(.body2sb)
                     .foregroundColor(.spoonBlack)
                     .padding(.top, 24)
                 
                 Text("정확한 지면(구/동),\n지하철역을 입력해보세요 ")
-                    .font(.body2m)
+                    .customFont(.body2m)
                     .foregroundColor(.gray500)
                     .multilineTextAlignment(.center)
             }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Search/Views/SearchResultRow.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Search/Views/SearchResultRow.swift
@@ -17,12 +17,12 @@ struct SearchResultRow: View {
                 HStack(spacing: 6) {
                     Image(.icPinGray600)
                     Text(result.title)
-                        .font(.body1b)
+                        .customFont(.body1b)
                         .foregroundStyle(.black)
                 }
                 
                 Text(result.address)
-                    .font(.body2b)
+                    .customFont(.body2b)
                     .foregroundStyle(.gray600)
                     .padding(.leading, 30)
             }

--- a/Spoony-iOS/Spoony-iOS/SpoonyApp.swift
+++ b/Spoony-iOS/Spoony-iOS/SpoonyApp.swift
@@ -13,9 +13,7 @@ struct SpoonyApp: App {
     
     var body: some Scene {
         WindowGroup {
-            SpoonyTabView()
-                .environmentObject(navigationManager)
-                .popup(popup: $navigationManager.popup)
+            DetailView()
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #128 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->

- 모든 폰트 행간 자간 설정 했습니다.

"이자카야~" 부분만 보시면 달라졌죠~?!

- 에러도 변경 했습니다.

|   변경 전   |   변경 후   |
| :-------------: | :----------: |
| <img src = "https://github.com/user-attachments/assets/94bbe1d3-3f8e-470c-803c-de45d9218ff9" width ="350"> | <img src = "https://github.com/user-attachments/assets/607f24f8-ab5a-40bf-826c-8b0a201fac24" width ="350"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->

- 이런 식으로 modifier를 만들어서 구현 했습니다 !!
```swift
public struct CustomFontModifier: ViewModifier {
    let font: Font
    let lineSpacing: CGFloat = 1.45
    let letterSpacing: CGFloat = -0.02
    
    /// 행 자간을 설정해주는 modifier 입니다.
    public func body(content: Content) -> some View {
        content
            .font(font)
            .lineSpacing(lineSpacing)
            .tracking(letterSpacing)
    }
}
```

- 사용 방법

```swift
Text("텍스트")
    .customFont(.body1b)
```
