### PR TITLE
[Fix] #137 RegisterView 버그 수정 

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/SpoonyTextField.swift
@@ -175,7 +175,7 @@ extension SpoonyTextField {
 extension SpoonyTextField {
     private func checkInputError(_ input: String) -> TextFieldErrorState {
         let trimmedText = text.replacingOccurrences(of: " ", with: "")
-        let regex = "^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣\\x20\\p{P}]*$"
+        let regex = "^[a-zA-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣\\x20\\p{P}\\$\\^\\+=₩|~<>¥£]*$"
         let predicate = NSPredicate(format: "SELF MATCHES %@", regex)
         
         if !predicate.evaluate(with: input) {

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterIntent.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterIntent.swift
@@ -28,4 +28,5 @@ enum RegisterIntent {
     case updatePickerItems([PhotosPickerItem])
     case deleteImage(UploadImage)
     case getCategories
+    case didTapPhoto([PhotosPickerItem])
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterState.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterState.swift
@@ -17,7 +17,7 @@ struct RegisterState {
     var recommendTexts: [TextList] = [.init()]
     
     var toast: Toast?
-    // 나중에 api 연결
+    
     var categorys: [CategoryChip] = []
     var selectedCategory: [CategoryChip] = []
     
@@ -34,7 +34,7 @@ struct RegisterState {
     var selectableCount = 5
     
     var selectedPlace: PlaceInfo?
-    // 나중에 api 연결
+    
     var searchedPlaces: [PlaceInfo] = []
     var pickerItems: [PhotosPickerItem] = []
     var uploadImages: [UploadImage] = []

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
@@ -145,13 +145,13 @@ final class RegisterStore: ObservableObject {
         case .getCategories:
             fetchCategories()
         case .didTapPhoto(let items):
-            delete(item: items)
+            validateSelectedPhotoCount(item: items)
         }
     }
 }
 
 extension RegisterStore {
-    private func delete(item: [PhotosPickerItem]) {
+    private func validateSelectedPhotoCount(item: [PhotosPickerItem]) {
         if item.count > state.selectableCount {
             state.pickerItems = Array(item.prefix(state.selectableCount))
             state.selectableCount = 0

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
@@ -144,32 +144,46 @@ final class RegisterStore: ObservableObject {
             }
         case .getCategories:
             fetchCategories()
+        case .didTapPhoto(let items):
+            delete(item: items)
         }
     }
 }
 
 extension RegisterStore {
-    private func loadImage() async {
-        for item in state.pickerItems {
-            do {
-                if let data = try await item.loadTransferable(type: Data.self),
-                   let jpegData = UIImage(data: data)?.jpegData(compressionQuality: 0.1),
-                   let image = UIImage(data: jpegData) {
-                    let image = Image(uiImage: image)
-                    
-                    await MainActor.run {
-                        state.uploadImages.append(.init(image: image, imageData: jpegData))
-                    }
-                }
-            } catch {
-                print("Error loading image: \(error)")
-            }
+    private func delete(item: [PhotosPickerItem]) {
+        if item.count > state.selectableCount {
+            state.pickerItems = Array(item.prefix(state.selectableCount))
+            state.selectableCount = 0
         }
+    }
+    private func loadImage() async {
         await MainActor.run {
             state.selectableCount -= state.pickerItems.count
-            state.pickerItems = []
-            state.uploadImageErrorState = .noError
-            secondButtonInavlid()
+        }
+        
+        if state.selectableCount >= 0 {
+            for item in state.pickerItems {
+                do {
+                    if let data = try await item.loadTransferable(type: Data.self),
+                       let jpegData = UIImage(data: data)?.jpegData(compressionQuality: 0.1),
+                       let image = UIImage(data: jpegData) {
+                        let image = Image(uiImage: image)
+                        
+                        await MainActor.run {
+                            state.uploadImages.append(.init(image: image, imageData: jpegData))
+                        }
+                    }
+                } catch {
+                    print("Error loading image: \(error)")
+                }
+            }
+            
+            await MainActor.run {
+                state.pickerItems = []
+                state.uploadImageErrorState = .noError
+                secondButtonInavlid()
+            }
         }
     }
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
@@ -34,7 +34,7 @@ struct InfoStepView: View {
         }))
         .task {
             store.dispatch(.getCategories)
-        }
+        }        
     }
 }
 
@@ -150,7 +150,7 @@ extension InfoStepView {
                     plusButton
                 }
             }
-        }
+        }        
     }
     
     private var dropDownView: some View {
@@ -224,7 +224,6 @@ extension InfoStepView {
                     } catch {
                         
                     }
-                    
                 }
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ReviewStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ReviewStepView.swift
@@ -174,7 +174,6 @@ extension ReviewStepView {
                     store.state.pickerItems
                 }, set: { newValue in
                     store.dispatch(.updatePickerItems(newValue))
-                    hideKeyboard()
                 }
             ),
             maxSelectionCount: store.state.selectableCount,
@@ -195,6 +194,14 @@ extension ReviewStepView {
                     .strokeBorder(.gray100)
             }
         }
+        .onChange(of: store.state.pickerItems, { _, newValue in
+            store.dispatch(.didTapPhoto(newValue))
+        })
+        .simultaneousGesture(
+            TapGesture().onEnded {
+                hideKeyboard()
+            }
+        )
         .disabled(store.state.uploadImages.count == 5)
     }
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ReviewStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/ReviewStepView.swift
@@ -34,7 +34,7 @@ struct ReviewStepView: View {
                     }
                 )
             ) {
-                store.dispatch(.didTapNextButton(.middle))                
+                store.dispatch(.didTapNextButton(.middle))
             }
             .padding(.bottom, 20)
         }
@@ -48,7 +48,7 @@ struct ReviewStepView: View {
                     store.dispatch(.movePreviousView)
                 }
             }
-)
+        )        
     }
 }
 


### PR DESCRIPTION
## 🔗 연결된 이슈
- close: #137 

## 📄 작업 내용
- PhotosPicker의 maxSelectionCount 이상의 사진이 선택되는 버그 수정
- 특정 특수문자 입력 안되는 버그 수정
- 사진 선택 후 키보드 다시 올리오는 현상 수정

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`RegisterStore`
- 새로 선택된 아이템 개수 검사하여 연타 입력시 추가되는 현상 방지
```swift
 private func validateSelectedPhotoCount(item: [PhotosPickerItem]) {
        if item.count > state.selectableCount {
            state.pickerItems = Array(item.prefix(state.selectableCount))
            state.selectableCount = 0
        }
    } 
```

`ReviewStepView`
- PhotosPickerItem의 변화를 감지하여 바로 추가 로직을 타지 않고 필터링 되도록 구현
```swift
PhotosPicker() {
생략
}
    .onChange(of: store.state.pickerItems, { _, newValue in
            store.dispatch(.didTapPhoto(newValue))
        })
```

## 👀 기타 더 이야기해볼 점
추천 메뉴 플러스 버튼과 마이너스 버튼 연타시 생기는 버그는 현재 재현이 안되어 나중에 다시 하겠습니다.
