### PR TITLE
[Feat] #153 -  네비게이션 탐색 상세 연결 했습니다.

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/Model/CardPlaceModel.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/CardPlaceModel.swift
@@ -10,6 +10,7 @@ import Foundation
 struct CardPlace: Identifiable, Equatable {
     let id = UUID()
     let placeId: Int
+    let postId: Int
     let name: String
     let visitorCount: String
     let address: String

--- a/Spoony-iOS/Spoony-iOS/Network/Model/FeedResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/FeedResponse.swift
@@ -33,6 +33,7 @@ extension FeedResponse {
     func toEntity() -> FeedEntity {
         .init(
             id: UUID(),
+            postId: self.postId,
             userName: self.userName,
             userRegion: self.userRegion,
             title: self.title,

--- a/Spoony-iOS/Spoony-iOS/Network/Model/FeedResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/FeedResponse.swift
@@ -42,7 +42,7 @@ extension FeedResponse {
     }
     
     static let sample: FeedResponse = .init(
-        userId: 1,
+        userId: Config.userId,
         userName: "안용아안용",
         createdAt: "2025-01-19T22:58:53.622066",
         userRegion: "서울시 성북구",

--- a/Spoony-iOS/Spoony-iOS/Network/Model/MapFocusResponse.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/Model/MapFocusResponse.swift
@@ -35,6 +35,7 @@ extension FocusPlaceResponse {
     func toCardPlace() -> CardPlace {
         return CardPlace(
             placeId: placeId,
+            postId: postId,
             name: placeName,
             visitorCount: "\(zzimCount)",
             address: authorRegionName,

--- a/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/FixedBottomSheetView.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Components/BottomSheet/FixedBottomSheetView.swift
@@ -46,7 +46,7 @@ struct FixedBottomSheetView: View {
                         title: "떠먹으러 가기",
                         disabled: $isDisabled
                     ) {
-                        navigationManager.push(.detailView)
+                        navigationManager.push(.detailView(postId: 1))
                     }
                     .padding(.top, 8)
                 }

--- a/Spoony-iOS/Spoony-iOS/Resource/Tab/Model/ViewType.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Tab/Model/ViewType.swift
@@ -11,7 +11,7 @@ enum ViewType: Hashable {
     case test
     case searchView    // 검색 화면
     case locationView(title: String)  // 위치 선택 화면
-    case detailView   // 상세 화면
+    case detailView(postId: Int)   // 상세 화면
     
     case explore
     case report

--- a/Spoony-iOS/Spoony-iOS/Resource/Tab/NavigationManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Tab/NavigationManager.swift
@@ -27,7 +27,6 @@ final class NavigationManager: ObservableObject {
             Home()
         case .detailView(let postId):
             DetailView(postId: postId)
-            
         case .explore:
             Explore()
         case .report:

--- a/Spoony-iOS/Spoony-iOS/Resource/Tab/NavigationManager.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Tab/NavigationManager.swift
@@ -25,8 +25,9 @@ final class NavigationManager: ObservableObject {
             SearchView()
         case .locationView:
             Home()
-        case .detailView:
-            DetailView()
+        case .detailView(let postId):
+            DetailView(postId: postId)
+            
         case .explore:
             Explore()
         case .report:

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailService.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailService.swift
@@ -5,11 +5,7 @@
 //  Created by 이명진 on 1/23/25.
 //
 
-protocol DetailSeviceProtocol {
-    func getReviewDetail(userId: Int, postId: Int, completion: @escaping (Result<ReviewDetailModel, SNError>) -> Void)
-}
-
-public class DetailService: DetailSeviceProtocol {
+public class DetailService {
     
     let detailProvider = Providers.detailProvider
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailService.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailService.swift
@@ -5,7 +5,11 @@
 //  Created by 이명진 on 1/23/25.
 //
 
-public struct DetailService {
+protocol DetailSeviceProtocol {
+    func getReviewDetail(userId: Int, postId: Int, completion: @escaping (Result<ReviewDetailModel, SNError>) -> Void)
+}
+
+public class DetailService: DetailSeviceProtocol {
     
     let detailProvider = Providers.detailProvider
     
@@ -63,18 +67,21 @@ public struct DetailService {
         }
     }
     
-    func scoopReview(userId: Int, postId: Int) {
-        detailProvider.request(.scoopReview(userId: 1, postId: postId)) { result in
-            switch result {
-            case .success(let response):
-                do {
-                    _ = try response.map(BaseResponse<BlankData>.self)
-                    
-                } catch {
-                    print("decode map to error")
+    func scoopReview(userId: Int, postId: Int) async throws -> Bool {
+        
+        return try await withCheckedThrowingContinuation { continuation in
+            detailProvider.request(.scoopReview(userId: Config.userId, postId: postId)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        _ = try response.map(BaseResponse<BlankData>.self)
+                        return continuation.resume(returning: true)
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
-            case .failure(let error):
-                print("통신 실패: \(error)")
             }
         }
     }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailState.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailState.swift
@@ -29,7 +29,7 @@ struct DetailState {
     var iconUrl: String = ""
     var iconTextColor: String = ""
     var iconBackgroundColor: String = ""
-    var categoryColorResponse: DetailCategoryColorResponse = .init(categoryName: "", iconUrl: "", iconTextColor: "", iconBackgroundColor: "")
+    var categoryColorResponse: DetailCategoryColorResponse = .init(categoryName: "", iconUrl: "", iconTextColor: "", iconBackgroundColor: "", categoryId: 0)
     var isMine: Bool = true
     
     // 추가 상태

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
@@ -18,12 +18,14 @@ struct DetailView: View {
     // MARK: - Properties
     
     @EnvironmentObject private var navigationManager: NavigationManager
-    @ObservedObject private var store: DetailViewStore
-    @Binding private var postId: Int
     
-    init(store: DetailViewStore = DetailViewStore(), postId: Binding<Int> = .constant(1)) {
-        self.store = store
-        self._postId = postId
+    // ObservableObject 쓰면 안돼! 초기화가 되버림.
+    // StateObeject 는 초기화가 안됌 상태가 유지가 됌
+    @StateObject private var store: DetailViewStore = DetailViewStore()
+    let postId: Int
+    
+    init( postId: Int) {
+        self.postId = postId
     }
     
     private let userImage = Image(.icCafeBlue)
@@ -64,8 +66,8 @@ struct DetailView: View {
                     intent: .getInitialValue(userId: 30, postId: postId)
                 )
             }
-            .onChange(of: store.state.toast) { _, oldValue in
-                toastMessage = oldValue
+            .onChange(of: store.state.toast) { _, newValue in
+                toastMessage = newValue
             }
             
             bottomView
@@ -168,6 +170,7 @@ extension DetailView {
             
         }
         .padding(EdgeInsets(top: 0, leading: 20.adjusted, bottom: 32.adjustedH, trailing: 20.adjusted))
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
     
     private var placeInfoSection: some View {
@@ -201,7 +204,7 @@ extension DetailView {
             
         }
         .padding(.horizontal, 20.adjusted)
-        .blur(radius: !store.state.isScoop ? 8 : 0)
+        .blur(radius: store.state.isScoop ? 0 : 8)
     }
     
     private var menuInfo: some View {
@@ -250,21 +253,23 @@ extension DetailView {
                 isIcon: store.state.isScoop ? false : true,
                 disabled: .constant(false)
             ) {
+                print("⭐️")
                 
                 if store.state.isScoop {
                     store.send(intent: .pathInfoInNaverMaps)
                 } else {
                     navigationManager.popup = .useSpoon(action: {
                         store.send(intent: .scoopButtonDidTap)
-                        
                     })
                 }
+                
+                print("⭐️")
             }
             
             if store.state.isScoop {
                 Spacer()
                 
-                SpoonButton(store: store)
+                ScrapButton(store: store)
             }
         }
         .padding(.horizontal, 20.adjusted)
@@ -308,7 +313,7 @@ struct menuList: View {
     }
 }
 
-struct SpoonButton: View {
+struct ScrapButton: View {
     
     @ObservedObject private var store: DetailViewStore
     
@@ -344,6 +349,6 @@ struct Line: Shape {
     }
 }
 
-#Preview {
-    DetailView(store: DetailViewStore(), postId: .constant(1))
-}
+//#Preview {
+//    DetailView(store: DetailViewStore(), postId: 12)
+//}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailViewStore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailViewStore.swift
@@ -22,14 +22,15 @@ final class DetailViewStore: ObservableObject {
         case .scrapButtonDidTap(let isScrap):
             handleScrapButton(isScrap: isScrap)
         case .scoopButtonDidTap:
-            handleScoopButton()
+            Task {
+                try await handleScoopButton()
+            }
         case .addButtonDidTap:
             handleAddButton()
         case .pathInfoInNaverMaps:
             openNaverMaps()
         }
     }
-    
     
     // MARK: - Methods
     
@@ -97,11 +98,19 @@ final class DetailViewStore: ObservableObject {
     }
     
     // 떠먹기 버튼 처리
-    private func handleScoopButton() {
-        service.scoopReview(userId: state.userId, postId: state.postId)
-        //        state.isScoop = true
-        
-        self.fetchInitialData(userId: state.userId, postId: state.postId)
+    @MainActor
+    private func handleScoopButton() async throws {
+ 
+        do {
+            let data = try await service.scoopReview(userId: Config.userId, postId: state.postId)
+            
+            if data {
+                state.isScoop.toggle()
+            }
+            
+        } catch {
+            print(error.localizedDescription)
+        }
     }
     
     // 드롭 다운 버튼 처리

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
@@ -140,7 +140,7 @@ extension Explore {
                         .padding(.bottom, 12)
                         .padding(.horizontal, 20)
                         .onTapGesture {
-                            navigationManager.push(.detailView(postId: 1))
+                            navigationManager.push(.detailView(postId: list.postId))
                         }
                 }
             }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Explore.swift
@@ -140,7 +140,7 @@ extension Explore {
                         .padding(.bottom, 12)
                         .padding(.horizontal, 20)
                         .onTapGesture {
-                            navigationManager.push(.detailView)
+                            navigationManager.push(.detailView(postId: 1))
                         }
                 }
             }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Model/FeedEntity.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Explore/Model/FeedEntity.swift
@@ -14,6 +14,7 @@ struct FeedEntity: Identifiable, Hashable {
     }
     
     let id: UUID
+    let postId: Int
     let userName: String
     let userRegion: String
     let title: String

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Components/PlaceHolderCardView/PlaceCard.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Components/PlaceHolderCardView/PlaceCard.swift
@@ -8,35 +8,40 @@
 import SwiftUI
 
 struct PlaceCard: View {
+    @EnvironmentObject var navigationManager: NavigationManager
     let places: [CardPlace]
     @Binding var currentPage: Int
     
     var body: some View {
-            VStack(spacing: 0) {
-                TabView(selection: $currentPage) {
-                    ForEach(places.indices, id: \.self) { index in
-                        PlaceCardItem(place: places[index])
-                            .tag(index)
-                            .padding(.horizontal, 26)
-                    }
+        VStack(spacing: 0) {
+            TabView(selection: $currentPage) {
+                ForEach(self.places.indices, id: \.self) { index in
+                    PlaceCardItem(place: places[index])
+                        .tag(index)
+                        .padding(.horizontal, 26)
+                        .onTapGesture {
+                            let postId = places[index].placeId
+                            navigationManager.push(.detailView(postId: postId))
+                        }
                 }
-                .frame(maxWidth: .infinity)
-                .frame(height: 264.adjusted)
-                .tabViewStyle(.page(indexDisplayMode: .never))
-                .background(.clear)
-                
-                ZStack {
-                    if places.count > 1 {
-                        PageIndicator(
-                            currentPage: currentPage,
-                            pageCount: places.count
-                        )
-                        .padding(.vertical, 4)
-                    }
-                }
-                .frame(height: 8) 
             }
+            .frame(maxWidth: .infinity)
+            .frame(height: 264.adjusted)
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .background(.clear)
+            
+            ZStack {
+                if places.count > 1 {
+                    PageIndicator(
+                        currentPage: currentPage,
+                        pageCount: places.count
+                    )
+                    .padding(.vertical, 4)
+                }
+            }
+            .frame(height: 8)
         }
+    }
 }
 
 private struct PlaceCardItem: View {
@@ -67,7 +72,7 @@ private struct PlaceCardItem: View {
             .background(Color.white)
             .clipShape(RoundedRectangle(cornerRadius: 10))
         }
-        .background(Color.clear) 
+        .background(Color.clear)
     }
 }
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/Home.swift
@@ -89,7 +89,7 @@ struct Home: View {
             isBottomSheetPresented = true
             Task {
                 do {
-                    spoonCount = try await restaurantService.fetchSpoonCount(userId: 1)
+                    spoonCount = try await restaurantService.fetchSpoonCount(userId: Config.userId)
                 } catch {
                     print("Failed to fetch spoon count:", error)
                 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Home/HomeViewModel.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Home/HomeViewModel.swift
@@ -24,7 +24,7 @@ final class HomeViewModel: ObservableObject {
         Task {
             isLoading = true
             do {
-                let response = try await service.fetchPickList(userId: 1)
+                let response = try await service.fetchPickList(userId: Config.userId)
                 self.pickList = response.zzimCardResponses
             } catch {
                 self.error = error
@@ -41,7 +41,7 @@ final class HomeViewModel: ObservableObject {
                         selectedLocation = (selectedPlace.latitude, selectedPlace.longitude)
                     }
                     
-                    let response = try await service.fetchFocusedPlace(userId: 1, placeId: placeId)
+                    let response = try await service.fetchFocusedPlace(userId: Config.userId, placeId: placeId)
                     self.focusedPlaces = response.zzimFocusResponseList.map { $0.toCardPlace() }
                 } catch {
                     self.error = error

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Model/DetailModel.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Model/DetailModel.swift
@@ -36,8 +36,8 @@ struct DetailCategoryColorResponse: Codable {
     let iconUrl: String
     let iconTextColor: String
     let iconBackgroundColor: String
+    let categoryId: Int // 추가된 필드
 }
-
 
 // MARK: - Entity
 

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
@@ -259,7 +259,7 @@ extension RegisterStore {
     
     private func checkDuplicatePlace(_ place: PlaceInfo) {
         let request = ValidatePlaceRequest(
-            userId: 1,
+            userId: Config.userId,
             latitude: place.latitude,
             longitude: place.longitude
         )
@@ -290,7 +290,7 @@ extension RegisterStore {
         guard let selectedPlace = state.selectedPlace,
               let selectedCategory = state.selectedCategory.first else { return }
         let request = RegisterPostRequest(
-            userId: 1,
+            userId: Config.userId,
             title: state.simpleText,
             description: state.detailText,
             placeName: selectedPlace.placeName,


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #153

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 네비게이션 탐색 연결 했습니다.
- 떠먹기 기능 안되는 문제 해결 했습니다.

| 탐색 -> 상세 + 떠먹기 기능  |
| :-------------: | 
 | <img src = "https://github.com/user-attachments/assets/438f94ea-f7f6-4c6c-b63f-9157713600ff" width ="250"> |

## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`코드 설명할 파일 이름 (ex: HomeView)`
- 기존 코드 Concurrency 적용 했습니다.
떠먹기 기능이 completion 작동이 안되기 때문에 이 부분만 수정 했습니다. 나머지도 나중에 해결 하겠습니다.
```swift
func scoopReview(userId: Int, postId: Int) async throws -> Bool {
    return try await withCheckedThrowingContinuation { continuation in
        detailProvider.request(.scoopReview(userId: Config.userId, postId: postId)) { result in
            switch result {
            case .success(let response):
                do {
                    _ = try response.map(BaseResponse<BlankData>.self)
                    return continuation.resume(returning: true)
                } catch {
                    continuation.resume(throwing: error)
                }
            case .failure(let error):
                continuation.resume(throwing: error)
            }
        }
    }
}
```

## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

completionHandler가 왜 호출이 안될까요 ..? 왜 메모리가 해제가 되는건지 !!!
