### PR TITLE
 [Feat] #149 - 키보드 활성화 여부에 따른 자동 스크롤 구현

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Components/ChipsContainerView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Components/ChipsContainerView.swift
@@ -14,7 +14,7 @@ struct ChipsContainerView: View {
     let horizontalSpacing: CGFloat
     let items: [CategoryChip]
     var sortedItems: [CategoryChip] {
-        items.sorted { $0.id > $1.id }
+        items.sorted { $0.id < $1.id }
     }
     
     init(

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterIntent.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterIntent.swift
@@ -29,4 +29,5 @@ enum RegisterIntent {
     case deleteImage(UploadImage)
     case getCategories
     case didTapPhoto([PhotosPickerItem])
+    case updateKeyboardHeight(CGFloat)
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterState.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterState.swift
@@ -14,10 +14,11 @@ struct RegisterState {
     
     // MARK: - InfoStepView
     var placeText: String = ""
-    var recommendTexts: [TextList] = [.init()]
+    
+    var keyboardHeight: CGFloat = 0
     
     var toast: Toast?
-    
+    var recommendTexts: [TextList] = [.init()]
     var categorys: [CategoryChip] = []
     var selectedCategory: [CategoryChip] = []
     

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/State/RegisterStore.swift
@@ -146,6 +146,8 @@ final class RegisterStore: ObservableObject {
             fetchCategories()
         case .didTapPhoto(let items):
             validateSelectedPhotoCount(item: items)
+        case .updateKeyboardHeight(let height):
+            state.keyboardHeight = height
         }
     }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/InfoStepView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct InfoStepView: View {
     @ObservedObject private var store: RegisterStore
+    @FocusState private var isPlaceTextFieldFocused: Bool
     
     init(store: RegisterStore) {
         self.store = store
@@ -86,6 +87,7 @@ extension InfoStepView {
                 ) {
                     store.dispatch(.didTapButtonIcon(.place))
                 }
+                .focused($isPlaceTextFieldFocused)
                 .onSubmit {
                     store.dispatch(.didTapkeyboardEnter)
                 }
@@ -225,7 +227,9 @@ extension InfoStepView {
                 ) { notification in
                     if let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                         withAnimation(.smooth) {
-                            store.dispatch(.updateKeyboardHeight(frame.height))
+                            if !isPlaceTextFieldFocused {
+                                store.dispatch(.updateKeyboardHeight(frame.height))
+                            }
                         }
                     }
                 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/Register.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/Register.swift
@@ -30,12 +30,7 @@ struct Register: View {
             .simultaneousGesture(
                 DragGesture()
                     .onChanged { _ in
-                        UIApplication.shared.sendAction(
-                            #selector(UIResponder.resignFirstResponder),
-                            to: nil,
-                            from: nil,
-                            for: nil
-                        )
+                        hideKeyboard()
                     }
             )
         }
@@ -78,8 +73,4 @@ enum RegisterStep: Int {
     case start = 1
     case middle = 2
     case end = 3
-}
-
-#Preview {
-    Register(store: .init(navigationManager: .init()))
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/Register.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/View/Register.swift
@@ -26,6 +26,18 @@ struct Register: View {
                 .transition(.slide)
                 .animation(.easeInOut, value: store.state.registerStep)
             }
+            .scrollIndicators(.hidden)
+            .simultaneousGesture(
+                DragGesture()
+                    .onChanged { _ in
+                        UIApplication.shared.sendAction(
+                            #selector(UIResponder.resignFirstResponder),
+                            to: nil,
+                            from: nil,
+                            for: nil
+                        )
+                    }
+            )
         }
     }
 }


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #149 

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 키보드 활성화 여부에 따른 자동 스크롤 구현
- QA 카테고리 칩 순서 수정 사항 반영

## 📄 실행 영상

https://github.com/user-attachments/assets/eed0c5d8-002b-4b69-b8cd-03db816603c7

## 💻 주요 코드 설명
`InfoStepView`
- ScrollViewReader의 proxy를 이용하여 자동 스크롤 구현
- .onAppear 시에 키보드 활성화/비활성화를 감지하도록 하여 키보드 keyboardHeight 업데이트
- keyboardHeight에 따라 bottom 기준으로 padding 추가
```swift
ScrollViewReader { proxy in
            VStack { ... }
            .onAppear {
                NotificationCenter.default.addObserver(
                    forName: UIResponder.keyboardWillShowNotification,
                    object: nil,
                    queue: .main
                ) { notification in
                    if let frame = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? CGRect {
                        withAnimation(.smooth) {
                            store.dispatch(.updateKeyboardHeight(frame.height))
                        }
                    }
                }
                
                NotificationCenter.default.addObserver(
                    forName: UIResponder.keyboardWillHideNotification,
                    object: nil,
                    queue: .main
                ) { _ in
                    withAnimation(.smooth) {
                        store.dispatch(.updateKeyboardHeight(0))
                    }
                }
            }
            .id("nextButton")
            .padding(.bottom, store.state.keyboardHeight)
            .ignoresSafeArea(.keyboard)
            .onChange(of: store.state.keyboardHeight) { _, newValue in
                if newValue != 0 {
                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
                        withAnimation {
                            proxy.scrollTo("nextButton", anchor: .bottom)
                        }
                    }
                }
            }
```
