### PR TITLE
[Feat] #174 - 유저 프로필을 받아오는 API를 연결 했습니다.

### DIFF
--- a/Spoony-iOS/Spoony-iOS/Network/TargetType/DetailTargetType.swift
+++ b/Spoony-iOS/Spoony-iOS/Network/TargetType/DetailTargetType.swift
@@ -13,6 +13,7 @@ enum DetailTargetType {
     case scoopReview(userId: Int, postId: Int)
     case scrapReview(userId: Int, postId: Int)
     case unScrapReview(userId: Int, postId: Int)
+    case getUserInfo(userId: Int)
 }
 
 extension DetailTargetType: TargetType {
@@ -34,12 +35,14 @@ extension DetailTargetType: TargetType {
             return "/post/zzim"
         case .unScrapReview(let userId, let postId):
             return "/post/zzim/\(userId)/\(postId)"
+        case .getUserInfo(let userId):
+            return "/user/\(userId)"
         }
     }
     
     var method: Moya.Method {
         switch self {
-        case .getDetailReview:
+        case .getDetailReview, .getUserInfo:
             return .get
         case .scoopReview,
                 .scrapReview:
@@ -51,7 +54,7 @@ extension DetailTargetType: TargetType {
     
     var task: Moya.Task {
         switch self {
-        case .getDetailReview:
+        case .getDetailReview, .getUserInfo:
             return .requestPlain
         case .scoopReview(let userId, let postId), .scrapReview(let userId, let postId):
             return .requestParameters(

--- a/Spoony-iOS/Spoony-iOS/Resource/Helper/ToastModifier.swift
+++ b/Spoony-iOS/Spoony-iOS/Resource/Helper/ToastModifier.swift
@@ -111,7 +111,3 @@ struct ToastModifier: ViewModifier {
         workItem = nil
     }
 }
-
-#Preview {
-    ContentView()
-}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailService.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailService.swift
@@ -82,4 +82,26 @@ public class DetailService {
             }
         }
     }
+    
+    func getUserInfo(userId: Int) async throws -> UserInfoModel {
+        return try await withCheckedThrowingContinuation { continuation in
+            detailProvider.request(.getUserInfo(userId: userId)) { result in
+                switch result {
+                case .success(let response):
+                    do {
+                        let result = try response.map(BaseResponse<UserInfoModel>.self)
+                        if let result = result.data {
+                            return continuation.resume(returning: result)
+                        } else {
+                            print("옵셔널 바인딩 X")
+                        }
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailState.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailState.swift
@@ -39,4 +39,5 @@ struct DetailState {
     var toast: Toast?
     
     var successService: Bool = true
+    var userInfo: UserInfoModel = .init(userId: 30, userEmail: "", userName: "", userImageUrl: "", regionName: "", createdAt: "", updatedAt: "")
 }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/DetailView.swift
@@ -24,7 +24,7 @@ struct DetailView: View {
     @StateObject private var store: DetailViewStore = DetailViewStore()
     let postId: Int
     
-    init( postId: Int) {
+    init(postId: Int) {
         self.postId = postId
     }
     
@@ -104,18 +104,17 @@ extension DetailView {
     private var userProfileSection: some View {
         HStack(alignment: .center, spacing: 14.adjustedH) {
             
-            Image(.imageThingjin)
-                .resizable()
+            RemoteImageView(urlString: store.state.userInfo.userImageUrl)
                 .scaledToFit()
                 .clipShape(Circle())
                 .frame(width: 48.adjusted, height: 48.adjustedH)
             
             VStack(alignment: .leading, spacing: 4.adjustedH) {
-                Text(store.state.userName)
+                Text(store.state.userInfo.userName)
                     .customFont(.body2b)
                     .foregroundStyle(.black)
                 
-                Text("서울시 성동구 수저")
+                Text(store.state.userInfo.regionName)
                     .customFont(.caption1m)
                     .foregroundStyle(.gray400)
             }

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/UserInfoModel.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Detail/DetailView/UserInfoModel.swift
@@ -1,0 +1,20 @@
+//
+//  UserInfoModel.swift
+//  Spoony-iOS
+//
+//  Created by 이명진 on 1/28/25.
+//
+
+import Foundation
+
+// MARK: - UserData
+
+struct UserInfoModel: Codable {
+    let userId: Int
+    let userEmail: String
+    let userName: String
+    let userImageUrl: String
+    let regionName: String
+    let createdAt: String
+    let updatedAt: String
+}

--- a/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Model/DetailModel.swift
+++ b/Spoony-iOS/Spoony-iOS/Source/Feature/Register/Model/DetailModel.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-
 // MARK: - ReviewDetailModel
 
 struct ReviewDetailModel: Codable {


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- close: #174

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->

- 탐색 상세뷰에, 유저 정보를 불러오는 API를 연결 했습니다. (빨간색 네모친 부분)

<   탐색 상세 뷰   >

<img width="376" alt="image" src="https://github.com/user-attachments/assets/3b870627-c567-42ab-a813-96ba41dd6c81" />


## 💻 주요 코드 설명
<!-- 코드 설명 없으면 제목까지 지워주세요! -->
`DetailService 파일에 API 함수 추가 했습니다.`

```swift
func getUserInfo(userId: Int) async throws -> UserInfoModel {
    return try await withCheckedThrowingContinuation { continuation in
        detailProvider.request(.getUserInfo(userId: userId)) { result in
            switch result {
            case .success(let response):
                do {
                    let result = try response.map(BaseResponse<UserInfoModel>.self)
                    if let result = result.data {
                        return continuation.resume(returning: result)
                    } else {
                        print("옵셔널 바인딩 X")
                    }
                } catch {
                    continuation.resume(throwing: error)
                }
            case .failure(let error):
                continuation.resume(throwing: error)
            }
        }
    }
}
```


## 👀 기타 더 이야기해볼 점
<!-- 있으면 작성하고 없으면 제목까지 완전히 지워주세요! -->

1. 전체적으로 코드가 너무 정리가 안되어있네요!!! 리팩토링을 해야겠어요
2. Concurrency를 너무 정형화 되어있게 사용만 하는거 같아요, 왜 이렇게 썼는지 생각 하면서 구현을 해야 겠어요!
